### PR TITLE
Merge setval branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,14 +29,13 @@ The basic property interface (API) requires / provides the following members:
 
 | Name           | (V) | Type                | Description
 | -------------- | :-: | ------------------- | -----------
-| **val**        |     | _mixed_             |  The actual property's data value.
+| **ident**      |     | _string_            | The property idenfifier (typically, its containing object matching property name).
 | **label**      |     | _TranslationString_ | ...
 | **l10n**       |     | _bool_              | If true, then the data should be stored in a l10n-aware structure (be translatable).s
 | **hidden**     |     | _bool_              |
 | **multiple**   |     | _bool_              | Multiple values can be held and stored, if true.
 | **required**   |  ✓  | _bool_              |
 | **unique**     |  ✓  | _bool_              |
-| **allow_null** |  ✓  | _bool_              |
 | **storable**   |     | _bool_              |
 | **active**     |     | _bool_              |
 <small>(V) indicates options used in validation</small>
@@ -45,12 +44,9 @@ The basic property interface (API) requires / provides the following members:
 
 ### Data retrieval
 
-The _raw_ data held in a property can be accessed with `setVal()` and `val()`.
-To get a string-safe, displaybale value, use `displayVal()`. To get the storage-ready format, use `storageSal()`.
-
-> ⚠ Even for string properties `val()` is not sure to return string values (a property can be multiple, or l10n, for example) so use `displayVal()` when working with displayable stirng is crucial.
-
-The `val()` value will be used for serialization and json serialization.
+- To get a normalized value, use the `parseVal($val)` method.
+- To get a string-safe, displaybale value, use `displayVal($val)`. 
+- To get the storage-ready format, use `storageVal($val)`. 
 
 ## Default validation
 
@@ -64,9 +60,9 @@ Validation is provided with a `Validator` object, from charcoal-core.
 
 Properties need 3 method to integrate with a SQL source:
 
--   `sql_extra()` _string_ Raw SQL string that will be appended to
--   `sql_type()` _string_ The SQL column type (ex: `VARCHAR(16)`)
--   `sql_pdo_type()` _integer_ The PDO column type (ex: `PDO::PARAM_STR`)
+-   `sqlExtra()` _string_ Raw SQL string that will be appended to
+-   `sqlType()` _string_ The SQL column type (ex: `VARCHAR(16)`)
+-   `sqlPdoType()` _integer_ The PDO column type (ex: `PDO::PARAM_STR`)
 
 >  Those methods are _abstract_ and therefore must be implemented in actual properties.
 
@@ -282,7 +278,7 @@ Object properties hold a reference to an external object of a certain type.
 
 ### Values
 
-The target's `identifer` (determined by its _obj-type_'s `key`, which is typically "id") is the only thing held in the value / stored in the database. When displayed (with `display_val()`), a string representation of the object should be rendered.
+The target's `identifer` (determined by its _obj-type_'s `key`, which is typically "id") is the only thing held in the value / stored in the database. When displayed (with `displayVal()`), a string representation of the object should be rendered.
 
 ### Object Property options
 

--- a/src/Charcoal/Property/AbstractProperty.php
+++ b/src/Charcoal/Property/AbstractProperty.php
@@ -629,8 +629,6 @@ abstract class AbstractProperty extends AbstractEntity implements
         return $this->notes;
     }
 
-
-
     /**
      * The property's default validation methods/
      *
@@ -715,9 +713,14 @@ abstract class AbstractProperty extends AbstractEntity implements
     }
 
     /**
+     * @param mixed The value, at time of saving.
      * @return mixed
      */
-    abstract public function save();
+    public function save($val)
+    {
+        // By default, nothing to do
+        return $val;
+    }
 
     /**
      * @param string $type The display type.

--- a/src/Charcoal/Property/AbstractProperty.php
+++ b/src/Charcoal/Property/AbstractProperty.php
@@ -719,7 +719,7 @@ abstract class AbstractProperty extends AbstractEntity implements
     public function save($val)
     {
         // By default, nothing to do
-        return $val;
+        return $this->parseVal($val);
     }
 
     /**

--- a/src/Charcoal/Property/AbstractProperty.php
+++ b/src/Charcoal/Property/AbstractProperty.php
@@ -713,7 +713,7 @@ abstract class AbstractProperty extends AbstractEntity implements
     }
 
     /**
-     * @param mixed The value, at time of saving.
+     * @param mixed $val The value, at time of saving.
      * @return mixed
      */
     public function save($val)

--- a/src/Charcoal/Property/AbstractProperty.php
+++ b/src/Charcoal/Property/AbstractProperty.php
@@ -286,8 +286,9 @@ abstract class AbstractProperty extends AbstractEntity implements
     /**
      * Parse the given value.
      *
-     * Note: the method returns the current value intact. Other properties can use this method to parse their values,
-     * such as {@see \Charcoal\Property\ObjectProperty::parseVal()} who could parse objects into object IDs.
+     * > Note: the base method (defined here) returns the current value intact.
+     * > Other properties can reimplement this method to parse their values,
+     * > such as {@see \Charcoal\Property\ObjectProperty::parseVal()} who could parse objects into object IDs.
      *
      * @param  mixed $val A value to be parsed.
      * @return mixed Returns the parsed value.
@@ -693,19 +694,6 @@ abstract class AbstractProperty extends AbstractEntity implements
             return false;
         }
         return true;
-    }
-
-    /**
-     * @param string $propertyIdent The ident of the property to retrieve.
-     * @return mixed
-     */
-    protected function propertyValue($propertyIdent)
-    {
-        if (isset($this->{$propertyIdent})) {
-            return $this->{$propertyIdent};
-        } else {
-            return null;
-        }
     }
 
     /**

--- a/src/Charcoal/Property/BooleanProperty.php
+++ b/src/Charcoal/Property/BooleanProperty.php
@@ -152,15 +152,16 @@ class BooleanProperty extends AbstractProperty
      */
     public function choices()
     {
+        $val = $this->val();
         return [
             [
                 'label'    => 'True',
-                'selected' => !!($this->val()),
+                'selected' => !!$val,
                 'value'    => 1
             ],
             [
                 'label'    => 'False',
-                'selected' => !($this->val()),
+                'selected' => !$val,
                 'value'    => 0
             ]
         ];

--- a/src/Charcoal/Property/BooleanProperty.php
+++ b/src/Charcoal/Property/BooleanProperty.php
@@ -130,7 +130,7 @@ class BooleanProperty extends AbstractProperty
     /**
      * Get the SQL type (Storage format)
      *
-     * Stored as `TINYINT(1) UNSIGNED`
+     * Boolean properties are stored as `TINYINT(1) UNSIGNED`
      *
      * @return string The SQL type
      */
@@ -165,13 +165,5 @@ class BooleanProperty extends AbstractProperty
                 'value'    => 0
             ]
         ];
-    }
-
-    /**
-     * @return mixed
-     */
-    public function save()
-    {
-        return $this->val();
     }
 }

--- a/src/Charcoal/Property/ColorProperty.php
+++ b/src/Charcoal/Property/ColorProperty.php
@@ -161,14 +161,6 @@ class ColorProperty extends AbstractProperty
     }
 
     /**
-     * @return mixed
-     */
-    public function save()
-    {
-        return $this->val();
-    }
-
-    /**
      * @param string|array $val The color array or string to parse.
      * @return array The parsed `[r,g,b,a]` color array.
      */

--- a/src/Charcoal/Property/ColorProperty.php
+++ b/src/Charcoal/Property/ColorProperty.php
@@ -55,12 +55,11 @@ class ColorProperty extends AbstractProperty
      * @throws InvalidArgumentException If the value does not match property's options.
      * @return ColorProperty Chainable
      */
-    public function setVal($val)
+    public function parseVal($val)
     {
         if ($val === null) {
             if ($this->allowNull()) {
-                $this->val = null;
-                return $this;
+                return null;
             } else {
                 throw new InvalidArgumentException(
                     'Val can not be null (Not allowed)'
@@ -80,11 +79,10 @@ class ColorProperty extends AbstractProperty
             foreach ($val as $v) {
                 $ret[] = $this->colorVal($v);
             }
-            $this->val = $ret;
+            return $ret;
         } else {
-            $this->val = $this->colorVal($val);
+            return $this->colorVal($val);
         }
-        return $this;
     }
 
     /**

--- a/src/Charcoal/Property/DateTimeProperty.php
+++ b/src/Charcoal/Property/DateTimeProperty.php
@@ -292,14 +292,6 @@ class DateTimeProperty extends AbstractProperty
     }
 
     /**
-     * @return mixed
-     */
-    public function save()
-    {
-        return $this->val();
-    }
-
-    /**
      * @return array
      */
     public function validationMethods()

--- a/src/Charcoal/Property/DateTimeProperty.php
+++ b/src/Charcoal/Property/DateTimeProperty.php
@@ -80,13 +80,11 @@ class DateTimeProperty extends AbstractProperty
      * AbstractProperty > setVal(). Ensure `DateTime` object in val.
      *
      * @param string|DateTime $val The value to set.
-     * @throws InvalidArgumentException If the value is invalid.
-     * @return DateTimeProperty Chainable
+     * @return DateTime|null
      */
-    public function setVal($val)
+    public function parseVal($val)
     {
-        $this->val = $this->dateTimeVal($val);
-        return $this;
+        return $this->dateTimeVal($val);
     }
 
     /**
@@ -127,7 +125,9 @@ class DateTimeProperty extends AbstractProperty
             if ($this->allowNull()) {
                 return null;
             } else {
-                throw new Exception('Invalid date/time value');
+                throw new Exception(
+                    'Invalid date/time value'
+                );
             }
         }
     }
@@ -137,9 +137,8 @@ class DateTimeProperty extends AbstractProperty
      *
      * > Warning: Passing a value as a parameter sets this value in the objects (calls setVal())
      *
-     * @param mixed $val Optional.
-     * @todo   Adapt for l10n
-     * @return string|null
+     * @param mixed $val The value to display.
+     * @return string
      */
     public function displayVal($val)
     {
@@ -155,7 +154,7 @@ class DateTimeProperty extends AbstractProperty
     /**
      * @param mixed $val Value to convert to DateTime.
      * @throws InvalidArgumentException If the value is not a valid datetime.
-     * @return DateTime
+     * @return DateTime|null
      */
     private function dateTimeVal($val)
     {

--- a/src/Charcoal/Property/DateTimeProperty.php
+++ b/src/Charcoal/Property/DateTimeProperty.php
@@ -100,7 +100,7 @@ class DateTimeProperty extends AbstractProperty
         $val = $this->dateTimeVal($val);
 
         if ($val instanceof DateTimeInterface) {
-            return $this->val->format('Y-m-d H:i:s');
+            return $val->format('Y-m-d H:i:s');
         } elseif (is_string($val)) {
             return $val;
         } else {
@@ -362,24 +362,5 @@ class DateTimeProperty extends AbstractProperty
     public function sqlPdoType()
     {
         return PDO::PARAM_STR;
-    }
-
-    /**
-     * Json Serialize
-     *
-     * @return mixed
-     */
-    public function jsonSerialize()
-    {
-        $val = $this->val();
-        if ($val === null) {
-            return null;
-        }
-
-        if ($val instanceof DateTimeInterface) {
-            return $val->format(DateTime::ATOM);
-        } else {
-            return $val;
-        }
     }
 }

--- a/src/Charcoal/Property/DescribablePropertyTrait.php
+++ b/src/Charcoal/Property/DescribablePropertyTrait.php
@@ -47,7 +47,7 @@ trait DescribablePropertyTrait
      * @throws RuntimeException If the property factory was not previously set.
      * @return FactoryInterface
      */
-    public function propertyFactory()
+    protected function propertyFactory()
     {
         if ($this->propertyFactory === null) {
             throw new RuntimeException(
@@ -212,12 +212,4 @@ trait DescribablePropertyTrait
 
         return isset($props[$propertyIdent]);
     }
-
-    /**
-     * Retrieve the value of the given property.
-     *
-     * @param string $propertyIdent The property identifier to retrieve the value for.
-     * @return mixed
-     */
-    abstract protected function propertyValue($propertyIdent);
 }

--- a/src/Charcoal/Property/DescribablePropertyTrait.php
+++ b/src/Charcoal/Property/DescribablePropertyTrait.php
@@ -102,11 +102,6 @@ trait DescribablePropertyTrait
             $metadata->setPropertyObject($propertyIdent, $property);
         }
 
-        $propertyValue = $this->propertyValue($propertyIdent);
-        if ($propertyValue !== null || $propertyIdent === $this->key()) {
-            $property->setVal($propertyValue);
-        }
-
         return $property;
     }
 

--- a/src/Charcoal/Property/FileProperty.php
+++ b/src/Charcoal/Property/FileProperty.php
@@ -465,12 +465,10 @@ class FileProperty extends AbstractProperty
     /**
      * @return mixed
      */
-    public function save()
+    public function save($val)
     {
         // Current ident
         $i = $this->ident();
-
-        $val = $this->val();
 
         if (isset($_FILES[$i])
             && (isset($_FILES[$i]['name']) && $_FILES[$i]['name'])
@@ -534,7 +532,6 @@ class FileProperty extends AbstractProperty
             } else {
                 $f = $this->fileUpload($file);
             }
-            $this->setVal($f);
             return $f;
         }
 
@@ -547,17 +544,15 @@ class FileProperty extends AbstractProperty
             for (; $k<$total; $k++) {
                 if (preg_match('/^data:/', $val[$k])) {
                     $f[] = $this->dataUpload($val[$k]);
-                    $this->setVal($f);
                     return $f;
                 }
             }
         } elseif (preg_match('/^data:/', $val)) {
             $f = $this->dataUpload($val);
-            $this->setVal($f);
             return $f;
         }
 
-        return $this->val();
+        return $val;
     }
 
     /**

--- a/src/Charcoal/Property/FileProperty.php
+++ b/src/Charcoal/Property/FileProperty.php
@@ -463,6 +463,7 @@ class FileProperty extends AbstractProperty
     }
 
     /**
+     * @param mixed $val The value, at time of saving.
      * @return mixed
      */
     public function save($val)

--- a/src/Charcoal/Property/GenericProperty.php
+++ b/src/Charcoal/Property/GenericProperty.php
@@ -48,12 +48,4 @@ class GenericProperty extends AbstractProperty
     {
         return PDO::PARAM_STR;
     }
-
-    /**
-     * @return mixed
-     */
-    public function save()
-    {
-        return $this->val();
-    }
 }

--- a/src/Charcoal/Property/IdProperty.php
+++ b/src/Charcoal/Property/IdProperty.php
@@ -172,17 +172,12 @@ class IdProperty extends AbstractProperty
      *
      * If no ID is set upon first save, then auto-generate it if necessary.
      *
-     * @see Charcoal_Object::save()
      * @return mixed
      */
-    public function save()
+    public function save($val)
     {
-        $val = $this->val();
-
         if (!$val) {
             $val = $this->autoGenerate();
-            // @TODO Can this setVal call be removed?
-            $this->setVal($val);
         }
 
         return $val;

--- a/src/Charcoal/Property/IdProperty.php
+++ b/src/Charcoal/Property/IdProperty.php
@@ -172,6 +172,7 @@ class IdProperty extends AbstractProperty
      *
      * If no ID is set upon first save, then auto-generate it if necessary.
      *
+     * @param mixed $val The value, at time of saving.
      * @return mixed
      */
     public function save($val)

--- a/src/Charcoal/Property/IdProperty.php
+++ b/src/Charcoal/Property/IdProperty.php
@@ -181,6 +181,7 @@ class IdProperty extends AbstractProperty
 
         if (!$val) {
             $val = $this->autoGenerate();
+            // @TODO Can this setVal call be removed?
             $this->setVal($val);
         }
 

--- a/src/Charcoal/Property/IpProperty.php
+++ b/src/Charcoal/Property/IpProperty.php
@@ -131,19 +131,6 @@ class IpProperty extends AbstractProperty
     }
 
     /**
-     * Prepare the value for save.
-     *
-     * If no ID is set upon first save, then auto-generate it if necessary.
-     *
-     * @see Charcoal_Object::save()
-     * @return mixed
-     */
-    public function save()
-    {
-        return $this->val();
-    }
-
-    /**
      * Get the IP value as a long integer.
      *
      * @param mixed $val The value to convert (if necessary) to integer.

--- a/src/Charcoal/Property/IpProperty.php
+++ b/src/Charcoal/Property/IpProperty.php
@@ -8,8 +8,7 @@ use \InvalidArgumentException;
 // Dependencies from `PHP` extensions
 use \PDO;
 
-
-// Module `charcoal-core` dependencies
+// Intra-module (`charcoal-property`) dependencies
 use \Charcoal\Property\AbstractProperty;
 
 /**
@@ -116,7 +115,7 @@ class IpProperty extends AbstractProperty
         ];
         if (!in_array($mode, $validModes)) {
             throw new InvalidArgumentException(
-                'Can not set storage mode: invalid mode.'
+                'Can not set IP storage mode: invalid mode.'
             );
         }
         $this->storageMode = $mode;

--- a/src/Charcoal/Property/LangProperty.php
+++ b/src/Charcoal/Property/LangProperty.php
@@ -76,12 +76,4 @@ class LangProperty extends AbstractProperty implements SelectablePropertyInterfa
 
         return $choices;
     }
-
-    /**
-     * @return mixed
-     */
-    public function save()
-    {
-        return $this->val();
-    }
 }

--- a/src/Charcoal/Property/MapStructureProperty.php
+++ b/src/Charcoal/Property/MapStructureProperty.php
@@ -9,7 +9,7 @@ use \PDO;
 use \Charcoal\Property\AbstractProperty;
 
 /**
- * Audio Property.
+ * Map Structure Property.
  */
 class MapStructureProperty extends AbstractProperty
 {
@@ -45,13 +45,5 @@ class MapStructureProperty extends AbstractProperty
     public function sqlPdoType()
     {
         return PDO::PARAM_STR;
-    }
-
-    /**
-     * @return mixed
-     */
-    public function save()
-    {
-        return $this->val();
     }
 }

--- a/src/Charcoal/Property/MultiObjectProperty.php
+++ b/src/Charcoal/Property/MultiObjectProperty.php
@@ -154,12 +154,4 @@ class MultiObjectProperty extends AbstractProperty
     {
         return 0;
     }
-
-    /**
-     * @return mixed
-     */
-    public function save()
-    {
-        return $this->val();
-    }
 }

--- a/src/Charcoal/Property/NumberProperty.php
+++ b/src/Charcoal/Property/NumberProperty.php
@@ -53,12 +53,4 @@ class NumberProperty extends AbstractProperty
     {
         return PDO::PARAM_STR;
     }
-
-    /**
-     * @return mixed
-     */
-    public function save()
-    {
-        return $this->val();
-    }
 }

--- a/src/Charcoal/Property/ObjectProperty.php
+++ b/src/Charcoal/Property/ObjectProperty.php
@@ -360,14 +360,6 @@ class ObjectProperty extends AbstractProperty implements SelectablePropertyInter
     }
 
     /**
-     * @return mixed
-     */
-    public function save()
-    {
-        return $this->val();
-    }
-
-    /**
      * Retrieve a singleton of the {self::$objType} for prototyping.
      *
      * @return ModelInterface
@@ -498,6 +490,8 @@ class ObjectProperty extends AbstractProperty implements SelectablePropertyInter
 
     /**
      * Get the choices array map.
+     *
+     * Required by `SelectablePropertyInterface`.
      *
      * @return array
      */

--- a/src/Charcoal/Property/ObjectProperty.php
+++ b/src/Charcoal/Property/ObjectProperty.php
@@ -332,20 +332,6 @@ class ObjectProperty extends AbstractProperty implements SelectablePropertyInter
     }
 
     /**
-     * Set the property's value.
-     *
-     * @param  mixed $val The property (raw) value.
-     * @throws InvalidArgumentException If the value is invalid (NULL or not multiple when supposed to).
-     * @return PropertyInterface Chainable
-     */
-    public function setVal($val)
-    {
-        $val = $this->parseVal($val);
-
-        return parent::setVal($val);
-    }
-
-    /**
      * Get the property's value in a format suitable for storage.
      *
      * @param mixed $val Optional. The value to convert to storage value.

--- a/src/Charcoal/Property/PasswordProperty.php
+++ b/src/Charcoal/Property/PasswordProperty.php
@@ -21,6 +21,7 @@ class PasswordProperty extends StringProperty
     }
 
     /**
+     * @param mixed $val The value, at time of saving.
      * @return string
      */
     public function save($val)

--- a/src/Charcoal/Property/PasswordProperty.php
+++ b/src/Charcoal/Property/PasswordProperty.php
@@ -23,15 +23,13 @@ class PasswordProperty extends StringProperty
     /**
      * @return string
      */
-    public function save()
+    public function save($val)
     {
-        $password = $this->val();
-        $val = $this->val();
+        $password = $val;
 
         // Assuming the password_needs_rehash is set to true is the hash given isn't a hash
         if (password_needs_rehash($password, PASSWORD_DEFAULT)) {
             $val = password_hash($password, PASSWORD_DEFAULT);
-            $this->setVal($val);
         }
 
         return $val;

--- a/src/Charcoal/Property/PhoneProperty.php
+++ b/src/Charcoal/Property/PhoneProperty.php
@@ -6,6 +6,8 @@ use \Charcoal\Property\StringProperty;
 
 /**
  * Telephone Property
+ *
+ * Phone numbers.
  */
 class PhoneProperty extends StringProperty
 {
@@ -18,6 +20,8 @@ class PhoneProperty extends StringProperty
     }
 
     /**
+     * Set StringProperty's `defaultMaxLength` to 16 for phone numbers.
+     *
      * @return integer
      */
     public function defaultMaxLength()

--- a/src/Charcoal/Property/PropertyInterface.php
+++ b/src/Charcoal/Property/PropertyInterface.php
@@ -143,7 +143,7 @@ interface PropertyInterface
     public function active();
 
     /**
-     * @param mixed The value, at time of saving.
+     * @param mixed $val The value, at time of saving.
      * @return mixed
      */
     public function save($val);

--- a/src/Charcoal/Property/PropertyInterface.php
+++ b/src/Charcoal/Property/PropertyInterface.php
@@ -141,4 +141,10 @@ interface PropertyInterface
      * @return boolean
      */
     public function active();
+
+    /**
+     * @param mixed The value, at time of saving.
+     * @return mixed
+     */
+    public function save($val);
 }

--- a/src/Charcoal/Property/StorablePropertyTrait.php
+++ b/src/Charcoal/Property/StorablePropertyTrait.php
@@ -114,8 +114,6 @@ trait StorablePropertyTrait
      */
     private function fieldVal($fieldIdent, $val)
     {
-        //$val = $this->val();
-
         if ($val === null) {
             return null;
         }

--- a/src/Charcoal/Property/StringProperty.php
+++ b/src/Charcoal/Property/StringProperty.php
@@ -30,10 +30,12 @@ class StringProperty extends AbstractProperty implements SelectablePropertyInter
      * @var int $minLength
      */
     private $minLength;
+
     /**
      * @var int $maxLength
      */
     private $maxLength;
+
     /**
      * Defines a validation regular expression for this string.
      * @var string $regexp
@@ -254,7 +256,12 @@ class StringProperty extends AbstractProperty implements SelectablePropertyInter
     public function validationMethods()
     {
         $parentMethods = parent::validationMethods();
-        return array_merge($parentMethods, [ 'maxLength', 'minLength', 'regexp', 'allowEmpty' ]);
+        return array_merge($parentMethods, [
+            'maxLength',
+            'minLength',
+            'regexp',
+            'allowEmpty'
+        ]);
     }
 
     /**
@@ -405,13 +412,5 @@ class StringProperty extends AbstractProperty implements SelectablePropertyInter
     public function sqlPdoType()
     {
         return PDO::PARAM_STR;
-    }
-
-    /**
-     * @return mixed
-     */
-    public function save()
-    {
-        return $this->val();
     }
 }

--- a/src/Charcoal/Property/StructureProperty.php
+++ b/src/Charcoal/Property/StructureProperty.php
@@ -27,18 +27,17 @@ class StructureProperty extends AbstractProperty
     }
 
     /**
-     * AbstractProperty > setVal(). Ensure `DateTime` object in val.
+     * AbstractProperty > setVal(). Ensure val is an array
      *
      * @param string|array $val The value to set.
      * @throws InvalidArgumentException If the value is invalid.
      * @return DateTimeProperty Chainable
      */
-    public function setVal($val)
+    public function parseVal($val)
     {
         if ($val === null) {
             if ($this->allowNull()) {
-                $this->val = null;
-                return $this;
+                return null;
             } else {
                 throw new InvalidArgumentException(
                     'Val can not be null (Not allowed)'
@@ -48,8 +47,7 @@ class StructureProperty extends AbstractProperty
         if (!is_array($val)) {
             $val = json_decode($val, true);
         }
-        $this->val = $val;
-        return $this;
+        return $val;
     }
 
     /**

--- a/src/Charcoal/Property/StructureProperty.php
+++ b/src/Charcoal/Property/StructureProperty.php
@@ -74,12 +74,4 @@ class StructureProperty extends AbstractProperty
     {
         return PDO::PARAM_STR;
     }
-
-    /**
-     * @return mixed
-     */
-    public function save()
-    {
-        return $this->val();
-    }
 }

--- a/src/Charcoal/Property/TextProperty.php
+++ b/src/Charcoal/Property/TextProperty.php
@@ -10,7 +10,6 @@ use \Charcoal\Property\StringProperty;
  */
 class TextProperty extends StringProperty
 {
-
     /**
      * @return string
      */
@@ -20,6 +19,9 @@ class TextProperty extends StringProperty
     }
 
     /**
+     * String's default max length is overridden for the text property.
+     * (0 = no max length).
+     *
      * @return integer
      */
     public function defaultMaxLength()

--- a/tests/Charcoal/Property/AbstractPropertyTest.php
+++ b/tests/Charcoal/Property/AbstractPropertyTest.php
@@ -3,11 +3,14 @@
 namespace Charcoal\Tests\Property;
 
 /**
- * ## TODOs
- * - 2015-03-12:
+ *
  */
 class AbstractPropertyTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * Object under Test
+     * @var AbstractProperty
+     */
     public $obj;
 
     public function setUp()

--- a/tests/Charcoal/Property/AbstractPropertyTest.php
+++ b/tests/Charcoal/Property/AbstractPropertyTest.php
@@ -2,6 +2,8 @@
 
 namespace Charcoal\Tests\Property;
 
+use \Psr\Log\NullLogger;
+
 /**
  *
  */
@@ -15,7 +17,9 @@ class AbstractPropertyTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->obj = $this->getMockForAbstractClass('\Charcoal\Property\AbstractProperty');
+        $this->obj = $this->getMockForAbstractClass('\Charcoal\Property\AbstractProperty', [[
+            'logger' => new NullLogger()
+        ]]);
     }
 
     public function testSetIdent()

--- a/tests/Charcoal/Property/AudioPropertyTest.php
+++ b/tests/Charcoal/Property/AudioPropertyTest.php
@@ -19,16 +19,13 @@ class AudioPropertyTest extends \PHPUnit_Framework_TestCase
 
     public function testDefauls()
     {
-        $obj = $this->obj;
-
-        $this->assertEquals(0, $obj->minLength());
-        $this->assertEquals(0, $obj->maxLength());
+        $this->assertEquals(0, $this->obj->minLength());
+        $this->assertEquals(0, $this->obj->maxLength());
     }
 
     public function testType()
     {
-        $obj = $this->obj;
-        $this->assertEquals('audio', $obj->type());
+        $this->assertEquals('audio', $this->obj->type());
     }
 
     public function testSetData()

--- a/tests/Charcoal/Property/AudioPropertyTest.php
+++ b/tests/Charcoal/Property/AudioPropertyTest.php
@@ -2,6 +2,8 @@
 
 namespace Charcoal\Tests\Property;
 
+use \Psr\Log\NullLogger;
+
 use \Charcoal\Property\AudioProperty;
 
 /**
@@ -14,7 +16,9 @@ class AudioPropertyTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->obj = new AudioProperty();
+        $this->obj = new AudioProperty([
+            'logger' => new NullLogger()
+        ]);
     }
 
     public function testDefauls()

--- a/tests/Charcoal/Property/BooleanPropertyTest.php
+++ b/tests/Charcoal/Property/BooleanPropertyTest.php
@@ -23,36 +23,26 @@ class BooleanPropertyTest extends \PHPUnit_Framework_TestCase
     /**
      *
      */
-    public function testConstructor()
-    {
-        $obj = $this->obj;
-        $this->assertInstanceOf('\Charcoal\Property\BooleanProperty', $obj);
-    }
-
-    /**
-     *
-     */
     public function testType()
     {
-        $obj = $this->obj;
-        $this->assertEquals('boolean', $obj->type());
+        $this->assertEquals('boolean', $this->obj->type());
     }
 
     /**
-     *
+     * Assert that the boolean property 's `displayVal()` method:
+     * - return the proper label
      */
     public function testDisplayVal()
     {
-        $obj = $this->obj;
-        $obj->setTrueLabel('Oui');
-        $obj->setFalseLabel('Non');
+        $this->obj->setTrueLabel('Oui');
+        $this->obj->setFalseLabel('Non');
 
-        $this->assertEquals('Oui', $obj->displayVal(true));
-        $this->assertEquals('Non', $obj->displayVal(false));
+        $this->assertEquals('Oui', $this->obj->displayVal(true));
+        $this->assertEquals('Non', $this->obj->displayVal(false));
     }
 
     /**
-     * Assert that the `setMultiple()` method:
+     * Assert that the boolean property's `setMultiple()` method:
      * - set the multiple to false, if false or falsish value
      * - throws exception otherwise (truthish or invalid value)
      * - is chainable
@@ -62,19 +52,19 @@ class BooleanPropertyTest extends \PHPUnit_Framework_TestCase
         $obj = $this->obj;
         $ret = $obj->setMultiple(0);
         $this->assertSame($ret, $obj);
-        $this->assertSame(false, $ret->multiple());
+        $this->assertFalse($ret->multiple());
 
         $this->setExpectedException('\InvalidArgumentException');
         $obj->setMultiple(1);
     }
 
     /**
-     *
+     * Asserts that the boolean property is multiple by default
      */
     public function testMultiple()
     {
         $obj = $this->obj;
-        $this->assertSame(false, $obj->multiple());
+        $this->assertFalse($obj->multiple());
     }
 
     /**
@@ -139,8 +129,7 @@ class BooleanPropertyTest extends \PHPUnit_Framework_TestCase
      */
     public function testSqlType()
     {
-        $obj = $this->obj;
-        $this->assertEquals('TINYINT(1) UNSIGNED', $obj->sqlType());
+        $this->assertEquals('TINYINT(1) UNSIGNED', $this->obj->sqlType());
     }
 
     /**
@@ -148,8 +137,7 @@ class BooleanPropertyTest extends \PHPUnit_Framework_TestCase
      */
     public function testSqlPdoType()
     {
-        $obj = $this->obj;
-        $this->assertEquals(\PDO::PARAM_BOOL, $obj->sqlPdoType());
+        $this->assertEquals(\PDO::PARAM_BOOL, $this->obj->sqlPdoType());
     }
 
     /**

--- a/tests/Charcoal/Property/BooleanPropertyTest.php
+++ b/tests/Charcoal/Property/BooleanPropertyTest.php
@@ -2,6 +2,8 @@
 
 namespace Charcoal\Tests\Property;
 
+use \Psr\Log\NullLogger;
+
 use \Charcoal\Property\BooleanProperty as BooleanProperty;
 
 /**
@@ -17,7 +19,9 @@ class BooleanPropertyTest extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
-        $this->obj = new BooleanProperty();
+        $this->obj = new BooleanProperty([
+            'logger' => new NullLogger()
+        ]);
     }
 
     /**
@@ -169,10 +173,7 @@ class BooleanPropertyTest extends \PHPUnit_Framework_TestCase
     {
         $obj = $this->obj;
 
-        $obj->setVal(true);
-        $this->assertTrue($obj->save());
-
-        $obj->setVal(false);
-        $this->assertNotTrue($obj->save());
+        $this->assertTrue($obj->save(true));
+        $this->assertNotTrue($obj->save(false));
     }
 }

--- a/tests/Charcoal/Property/ColorPropertyTest.php
+++ b/tests/Charcoal/Property/ColorPropertyTest.php
@@ -2,6 +2,8 @@
 
 namespace Charcoal\Tests\Property;
 
+use \Psr\Log\NullLogger;
+
 use \Charcoal\Property\ColorProperty;
 
 class ColorPropertyTest extends \PHPUnit_Framework_TestCase
@@ -10,7 +12,9 @@ class ColorPropertyTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->obj = new ColorProperty();
+        $this->obj = new ColorProperty([
+            'logger' => new NullLogger()
+        ]);
     }
 
     protected static function callMethod($obj, $name, array $args = null)

--- a/tests/Charcoal/Property/DateTimePropertyTest.php
+++ b/tests/Charcoal/Property/DateTimePropertyTest.php
@@ -4,6 +4,8 @@ namespace Charcoal\Tests\Property;
 
 use \DateTime;
 
+use \Psr\Log\NullLogger;
+
 use \Charcoal\Property\DateTimeProperty;
 
 /**
@@ -22,7 +24,9 @@ class DateTimePropertyTest extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
-        $this->obj = new DateTimeProperty();
+        $this->obj = new DateTimeProperty([
+            'logger' => new NullLogger()
+        ]);
     }
 
     /**
@@ -195,10 +199,9 @@ class DateTimePropertyTest extends \PHPUnit_Framework_TestCase
 
     public function testSave()
     {
-        $this->assertEquals(null, $this->obj->save());
+        $this->assertEquals(null, $this->obj->save(null));
 
-        $this->obj->setVal('2015-01-01');
-        $this->assertEquals(new DateTime('2015-01-01'), $this->obj->save());
+        $this->assertEquals(new DateTime('2015-01-01'), $this->obj->save('2015-01-01'));
     }
 
     /**

--- a/tests/Charcoal/Property/FilePropertyTest.php
+++ b/tests/Charcoal/Property/FilePropertyTest.php
@@ -3,6 +3,9 @@
 namespace Charcoal\Tests\Property;
 
 use \InvalidArgumentException;
+
+use \Psr\Log\NullLogger;
+
 use \Charcoal\Property\FileProperty;
 
 /**
@@ -15,7 +18,9 @@ class FilePropertyTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->obj = new FileProperty();
+        $this->obj = new FileProperty([
+            'logger' => new NullLogger()
+        ]);
     }
 
     public function testConstructor()

--- a/tests/Charcoal/Property/GenericPropertyTest.php
+++ b/tests/Charcoal/Property/GenericPropertyTest.php
@@ -2,6 +2,8 @@
 
 namespace Charcoal\Tests\Model;
 
+use \Psr\Log\NullLogger;
+
 use \Charcoal\Property\PropertyFactory;
 use \Charcoal\Property\GenericProperty;
 
@@ -13,7 +15,7 @@ class PropertyTest extends \PHPUnit_Framework_TestCase
     public function getObj()
     {
         return $this->factory->create('GenericProperty', [
-            'logger' => new \Psr\Log\NullLogger()
+            'logger' => new NullLogger()
         ]);
     }
 

--- a/tests/Charcoal/Property/HtmlPropertyTest.php
+++ b/tests/Charcoal/Property/HtmlPropertyTest.php
@@ -2,6 +2,8 @@
 
 namespace Charcoal\Tests\Property;
 
+use \Psr\Log\NullLogger;
+
 use \Charcoal\Property\HtmlProperty;
 
 /**
@@ -13,7 +15,9 @@ class HtmlPropertyTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->obj = new HtmlProperty();
+        $this->obj = new HtmlProperty([
+            'logger' => new NullLogger()
+        ]);
     }
 
     public function testType()

--- a/tests/Charcoal/Property/IdPropertyTest.php
+++ b/tests/Charcoal/Property/IdPropertyTest.php
@@ -2,6 +2,8 @@
 
 namespace Charcoal\Tests\Property;
 
+use \Psr\Log\NullLogger;
+
 use \Charcoal\Property\IdProperty;
 
 /**
@@ -15,7 +17,9 @@ class IdPropertyTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->obj = new IdProperty();
+        $this->obj = new IdProperty([
+            'logger' => new NullLogger()
+        ]);
     }
 
     public function testType()
@@ -97,27 +101,24 @@ class IdPropertyTest extends \PHPUnit_Framework_TestCase
     {
         $obj = $this->obj;
         $obj->setMode('auto-increment');
-        $id = $obj->save();
-        $this->assertEquals($id, $obj->val());
-        $this->assertEquals('', $obj->val());
+        $id = $obj->save(null);
+        $this->assertEquals('', $id);
     }
 
     public function testSaveAndAutoGenerateUniqid()
     {
         $obj = $this->obj;
         $obj->setMode('uniqid');
-        $id = $obj->save();
-        $this->assertEquals($id, $obj->val());
-        $this->assertEquals(13, strlen($obj->val()));
+        $id = $obj->save(null);
+        $this->assertEquals(13, strlen($id));
     }
 
     public function testSaveAndAutoGenerateUuid()
     {
         $obj = $this->obj;
         $obj->setMode('uuid');
-        $id = $obj->save();
-        $this->assertEquals($id, $obj->val());
-        $this->assertEquals(36, strlen($obj->val()));
+        $id = $obj->save(null);
+        $this->assertEquals(36, strlen($id));
     }
 
     public function testSqlExtra()

--- a/tests/Charcoal/Property/ImagePropertyTest.php
+++ b/tests/Charcoal/Property/ImagePropertyTest.php
@@ -2,6 +2,8 @@
 
 namespace Charcoal\Tests\Property;
 
+use \Psr\Log\NullLogger;
+
 use \Charcoal\Property\ImageProperty;
 
 /**
@@ -14,7 +16,9 @@ class ImagePropertyTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->obj = new ImageProperty();
+        $this->obj = new ImageProperty([
+            'logger' => new NullLogger()
+        ]);
     }
 
     public function testType()

--- a/tests/Charcoal/Property/IpPropertyTest.php
+++ b/tests/Charcoal/Property/IpPropertyTest.php
@@ -4,6 +4,8 @@ namespace Charcoal\Tests\Property;
 
 use \PDO;
 
+use \Psr\Log\NullLogger;
+
 use \Charcoal\Property\IpProperty;
 
 /**
@@ -15,7 +17,9 @@ class IpPropertyTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->obj = new IpProperty();
+        $this->obj = new IpProperty([
+            'logger' => new NullLogger()
+        ]);
     }
 
     public function testType()

--- a/tests/Charcoal/Property/LangPropertyTest.php
+++ b/tests/Charcoal/Property/LangPropertyTest.php
@@ -5,11 +5,14 @@ namespace Charcoal\Tests\Property;
 use \Charcoal\Property\LangProperty;
 
 /**
- * ## TODOs
- * - 2015-03-12:
+ * Lang Property Test
  */
 class LangPropertyTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * Object under test
+     * @var LangProperty
+     */
     public $obj;
 
     public function setUp()
@@ -19,7 +22,25 @@ class LangPropertyTest extends \PHPUnit_Framework_TestCase
 
     public function testType()
     {
-        $obj = $this->obj;
-        $this->assertEquals('lang', $obj->type());
+        $this->assertEquals('lang', $this->obj->type());
+    }
+
+    public function testSqlExtra()
+    {
+        $this->assertEquals('', $this->obj->sqlExtra());
+    }
+
+    public function testSqlType()
+    {
+        $this->assertEquals('CHAR(2)', $this->obj->sqlType());
+        $this->obj->setMultiple(true);
+        $this->assertEquals('TEXT', $this->obj->sqlType());
+        $this->obj->setMultiple(false);
+        $this->assertEquals('CHAR(2)', $this->obj->sqlType());
+    }
+
+    public function testChoices()
+    {
+        //var_dump($this->obj->choices());
     }
 }

--- a/tests/Charcoal/Property/LangPropertyTest.php
+++ b/tests/Charcoal/Property/LangPropertyTest.php
@@ -2,6 +2,8 @@
 
 namespace Charcoal\Tests\Property;
 
+use \Psr\Log\NullLogger;
+
 use \Charcoal\Property\LangProperty;
 
 /**
@@ -17,7 +19,9 @@ class LangPropertyTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->obj = new LangProperty();
+        $this->obj = new LangProperty([
+            'logger' => new NullLogger()
+        ]);
     }
 
     public function testType()

--- a/tests/Charcoal/Property/MapStructurePropertyTest.php
+++ b/tests/Charcoal/Property/MapStructurePropertyTest.php
@@ -2,6 +2,8 @@
 
 namespace Charcoal\Tests\Property;
 
+use \Psr\Log\NullLogger;
+
 use \Charcoal\Property\MapStructureProperty;
 
 /**
@@ -17,7 +19,9 @@ class MapStructurePropertyTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->obj = new MapStructureProperty();
+        $this->obj = new MapStructureProperty([
+            'logger' => new NullLogger()
+        ]);
     }
 
     public function testType()

--- a/tests/Charcoal/Property/NumberPropertyTest.php
+++ b/tests/Charcoal/Property/NumberPropertyTest.php
@@ -2,6 +2,8 @@
 
 namespace Charcoal\Tests\Property;
 
+use \Psr\Log\NullLogger;
+
 use \Charcoal\Property\NumberProperty;
 
 /**
@@ -16,7 +18,9 @@ class NumberPropertyTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->obj = new NumberProperty();
+        $this->obj = new NumberProperty([
+            'logger' => new NullLogger()
+        ]);
     }
 
     public function testType()

--- a/tests/Charcoal/Property/ObjectPropertyTest.php
+++ b/tests/Charcoal/Property/ObjectPropertyTest.php
@@ -2,6 +2,8 @@
 
 namespace Charcoal\Tests\Property;
 
+use \Psr\Log\NullLogger;
+
 use \Charcoal\Property\ObjectProperty;
 
 /**
@@ -14,7 +16,9 @@ class ObjectPropertyTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->obj = new ObjectProperty();
+        $this->obj = new ObjectProperty([
+            'logger' => new NullLogger()
+        ]);
     }
 
     public function testType()

--- a/tests/Charcoal/Property/PasswordPropertyTest.php
+++ b/tests/Charcoal/Property/PasswordPropertyTest.php
@@ -2,7 +2,9 @@
 
 namespace Charcoal\Tests\Property;
 
-use \Charcoal\Property\PasswordProperty as PasswordProperty;
+use \Psr\Log\NullLogger;
+
+use \Charcoal\Property\PasswordProperty;
 
 /**
  * ## TODOs
@@ -12,7 +14,9 @@ class PasswordPropertyTest extends \PHPUnit_Framework_TestCase
 {
     public function testType()
     {
-        $obj = new PasswordProperty();
+        $obj = new PasswordProperty([
+            'logger' => new NullLogger()
+        ]);
         $this->assertEquals('password', $obj->type());
     }
 }

--- a/tests/Charcoal/Property/PhonePropertyTest.php
+++ b/tests/Charcoal/Property/PhonePropertyTest.php
@@ -2,6 +2,8 @@
 
 namespace Charcoal\Tests\Property;
 
+use \Psr\Log\NullLogger;
+
 use \Charcoal\Property\PhoneProperty;
 
 /**
@@ -19,7 +21,9 @@ class PhonePropertyTest extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
-        $this->obj = new PhoneProperty();
+        $this->obj = new PhoneProperty([
+            'logger' => new NullLogger()
+        ]);
     }
 
     /**

--- a/tests/Charcoal/Property/PropertyFieldTest.php
+++ b/tests/Charcoal/Property/PropertyFieldTest.php
@@ -2,6 +2,8 @@
 
 namespace Charcoal\Tests\Property;
 
+use \Psr\Log\NullLogger;
+
 use \Charcoal\Property\PropertyField;
 
 /**
@@ -13,7 +15,9 @@ class PropertyFieldTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->obj = new PropertyField();
+        $this->obj = new PropertyField([
+            'logger' => new NullLogger()
+        ]);
     }
 
     public function testSetIdent()

--- a/tests/Charcoal/Property/StringPropertyTest.php
+++ b/tests/Charcoal/Property/StringPropertyTest.php
@@ -2,6 +2,8 @@
 
 namespace Charcoal\Tests\Property;
 
+use \Psr\Log\NullLogger;
+
 use \Charcoal\Property\StringProperty;
 
 /**
@@ -21,7 +23,9 @@ class StringPropertyTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         mb_internal_encoding('UTF-8');
-        $this->obj = new StringProperty();
+        $this->obj = new StringProperty([
+            'logger' => new NullLogger()
+        ]);
     }
 
     /**

--- a/tests/Charcoal/Property/StructurePropertyTest.php
+++ b/tests/Charcoal/Property/StructurePropertyTest.php
@@ -2,6 +2,8 @@
 
 namespace Charcoal\Tests\Property;
 
+use \Psr\Log\NullLogger;
+
 use \Charcoal\Property\StructureProperty;
 
 /**
@@ -13,12 +15,16 @@ class StructurePropertyTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->obj = new StructureProperty();
+        $this->obj = new StructureProperty([
+            'logger' => new NullLogger()
+        ]);
     }
 
     public function testType()
     {
-        $obj = new StructureProperty();
+        $obj = new StructureProperty([
+            'logger' => new NullLogger()
+        ]);
         $this->assertEquals('structure', $obj->type());
     }
 }

--- a/tests/Charcoal/Property/TextPropertyTest.php
+++ b/tests/Charcoal/Property/TextPropertyTest.php
@@ -2,6 +2,8 @@
 
 namespace Charcoal\Tests\Property;
 
+use \Psr\Log\NullLogger;
+
 use \Charcoal\Property\TextProperty;
 
 /**
@@ -14,7 +16,9 @@ class TextPropertyTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->obj = new TextProperty();
+        $this->obj = new TextProperty([
+            'logger' => new NullLogger()
+        ]);
     }
 
     /**

--- a/tests/Charcoal/Property/UrlPropertyTest.php
+++ b/tests/Charcoal/Property/UrlPropertyTest.php
@@ -2,6 +2,8 @@
 
 namespace Charcoal\Tests\Property;
 
+use \Psr\Log\NullLogger;
+
 use \Charcoal\Property\UrlProperty;
 
 /**
@@ -13,7 +15,9 @@ class UrlPropertyTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->obj = new UrlProperty();
+        $this->obj = new UrlProperty([
+            'logger' => new NullLogger()
+        ]);
     }
 
     /**


### PR DESCRIPTION
- Removed most calls to `setVal()` and `val()` as they are going deprecated soon.
- Add a required paramter (`$val`) to the `save()` method
- Provide the `save($val)` method by default in AbstractProperty
- Fix README and unit tests