### PR TITLE
Move getters to getFoo().

### DIFF
--- a/src/Charcoal/Property/AbstractProperty.php
+++ b/src/Charcoal/Property/AbstractProperty.php
@@ -239,9 +239,14 @@ abstract class AbstractProperty extends AbstractEntity implements
      *
      * @return string
      */
-    public function ident()
+    public function getIdent()
     {
         return $this->ident;
+    }
+
+    public function ident()
+    {
+        return $this->getIdent();
     }
 
     /**
@@ -259,7 +264,7 @@ abstract class AbstractProperty extends AbstractEntity implements
             throw new RuntimeException('Missing Property Identifier');
         }
 
-        if (!$this->l10n()) {
+        if (!$this['l10n']) {
             throw new LogicException(sprintf(
                 'Property "%s" is not multilingual',
                 $this->ident
@@ -316,7 +321,7 @@ abstract class AbstractProperty extends AbstractEntity implements
      */
     final public function parseVal($val)
     {
-        if ($this->allowNull()) {
+        if ($this['allowNull']) {
             if ($val === null) {
                 return null;
             }
@@ -327,7 +332,7 @@ abstract class AbstractProperty extends AbstractEntity implements
             ));
         }
 
-        if ($this->multiple()) {
+        if ($this['multiple']) {
             if (is_string($val)) {
                 $val = explode($this->multipleSeparator(), $val);
             } else {
@@ -342,7 +347,7 @@ abstract class AbstractProperty extends AbstractEntity implements
             }
 
             if (empty($val) === true) {
-                if ($this->allowNull() === false) {
+                if ($this['allowNull'] === false) {
                     throw new InvalidArgumentException(sprintf(
                         'Property "%s" value can not be NULL or empty (not allowed)',
                         $this->ident()
@@ -353,7 +358,7 @@ abstract class AbstractProperty extends AbstractEntity implements
             }
             $val = array_map([ $this, 'parseOne' ], $val);
         } else {
-            if ($this->l10n()) {
+            if ($this['l10n']) {
                 $val = $this->translator()->translation($val);
                 if ($val) {
                     $val->sanitize([$this, 'parseOne']);
@@ -391,7 +396,7 @@ abstract class AbstractProperty extends AbstractEntity implements
         }
 
         /** Parse multilingual values */
-        if ($this->l10n()) {
+        if ($this['l10n']) {
             $propertyValue = $this->l10nVal($val, $options);
             if ($propertyValue === null) {
                 return '';
@@ -403,7 +408,7 @@ abstract class AbstractProperty extends AbstractEntity implements
         }
 
         /** Parse multiple values / ensure they are of array type. */
-        if ($this->multiple()) {
+        if ($this['multiple']) {
             if (is_array($propertyValue)) {
                 $propertyValue = implode($this->multipleSeparator(), $propertyValue);
             }
@@ -428,7 +433,7 @@ abstract class AbstractProperty extends AbstractEntity implements
         }
 
         /** Parse multilingual values */
-        if ($this->l10n()) {
+        if ($this['l10n']) {
             $propertyValue = $this->l10nVal($val, $options);
             if ($propertyValue === null) {
                 return '';
@@ -442,7 +447,7 @@ abstract class AbstractProperty extends AbstractEntity implements
         $separator = $this->multipleSeparator();
 
         /** Parse multiple values / ensure they are of array type. */
-        if ($this->multiple()) {
+        if ($this['multiple']) {
             if (!is_array($propertyValue)) {
                 $propertyValue = explode($separator, $propertyValue);
             }
@@ -475,7 +480,7 @@ abstract class AbstractProperty extends AbstractEntity implements
     /**
      * @return Translation
      */
-    public function label()
+    public function getLabel()
     {
         if ($this->label === null) {
             return ucwords(str_replace([ '.', '_' ], ' ', $this->ident()));
@@ -500,7 +505,7 @@ abstract class AbstractProperty extends AbstractEntity implements
      *
      * @return boolean
      */
-    public function l10n()
+    public function getL10n()
     {
         return $this->l10n;
     }
@@ -519,7 +524,7 @@ abstract class AbstractProperty extends AbstractEntity implements
     /**
      * @return boolean
      */
-    public function hidden()
+    public function getHidden()
     {
         return $this->hidden;
     }
@@ -559,7 +564,7 @@ abstract class AbstractProperty extends AbstractEntity implements
      *
      * @return boolean
      */
-    public function multiple()
+    public function getMultiple()
     {
         return $this->multiple;
     }
@@ -591,7 +596,7 @@ abstract class AbstractProperty extends AbstractEntity implements
      * @param  string|null $key Optional setting to retrieve from the options.
      * @return array|mixed|null
      */
-    public function multipleOptions($key = null)
+    public function getMultipleOptions($key = null)
     {
         if ($this->multipleOptions === null) {
             $this->multipleOptions = $this->defaultMultipleOptions();
@@ -615,7 +620,7 @@ abstract class AbstractProperty extends AbstractEntity implements
      */
     public function multipleOptionsAsJson()
     {
-        return json_encode($this->multipleOptions());
+        return json_encode($this->getMultipleOptions());
     }
 
     /**
@@ -639,7 +644,7 @@ abstract class AbstractProperty extends AbstractEntity implements
      */
     public function multipleSeparator()
     {
-        return $this->multipleOptions('separator');
+        return $this->getMultipleOptions('separator');
     }
 
     /**
@@ -661,7 +666,7 @@ abstract class AbstractProperty extends AbstractEntity implements
      *
      * @return boolean
      */
-    public function allowNull()
+    public function getAllowNull()
     {
         return $this->allowNull;
     }
@@ -685,7 +690,7 @@ abstract class AbstractProperty extends AbstractEntity implements
      *
      * @return boolean
      */
-    public function required()
+    public function getRequired()
     {
         return $this->required;
     }
@@ -704,7 +709,7 @@ abstract class AbstractProperty extends AbstractEntity implements
     /**
      * @return boolean
      */
-    public function unique()
+    public function getUnique()
     {
         return $this->unique;
     }
@@ -723,7 +728,7 @@ abstract class AbstractProperty extends AbstractEntity implements
     /**
      * @return boolean
      */
-    public function active()
+    public function getActive()
     {
         return $this->active;
     }
@@ -742,7 +747,7 @@ abstract class AbstractProperty extends AbstractEntity implements
     /**
      * @return boolean
      */
-    public function storable()
+    public function getStorable()
     {
         return $this->storable;
     }
@@ -760,7 +765,7 @@ abstract class AbstractProperty extends AbstractEntity implements
     /**
      * @return Translation|null
      */
-    public function description()
+    public function getDescription()
     {
         return $this->description;
     }
@@ -778,7 +783,7 @@ abstract class AbstractProperty extends AbstractEntity implements
     /**
      * @return Translation|null
      */
-    public function notes()
+    public function getNotes()
     {
         return $this->notes;
     }
@@ -809,7 +814,7 @@ abstract class AbstractProperty extends AbstractEntity implements
      */
     public function validateRequired()
     {
-        if ($this->required() && !$this->val()) {
+        if ($this['required'] && !$this->val()) {
             $this->validator()->error('Value is required.', 'required');
 
             return false;
@@ -823,7 +828,7 @@ abstract class AbstractProperty extends AbstractEntity implements
      */
     public function validateUnique()
     {
-        if (!$this->unique()) {
+        if (!$this['unique']) {
             return true;
         }
 
@@ -836,7 +841,7 @@ abstract class AbstractProperty extends AbstractEntity implements
      */
     public function validateAllowNull()
     {
-        if (!$this->allowNull() && $this->val() === null) {
+        if (!$this['allowNull'] && $this->val() === null) {
             $this->validator()->error('Value can not be null.', 'allowNull');
 
             return false;
@@ -871,7 +876,7 @@ abstract class AbstractProperty extends AbstractEntity implements
     /**
      * @return string
      */
-    public function displayType()
+    public function getDisplayType()
     {
         if (!$this->displayType) {
             $meta = $this->metadata();

--- a/src/Charcoal/Property/BooleanProperty.php
+++ b/src/Charcoal/Property/BooleanProperty.php
@@ -61,13 +61,13 @@ class BooleanProperty extends AbstractProperty
             if (isset($options['true_label'])) {
                 $label = $options['true_label'];
             } else {
-                $label = $this->trueLabel();
+                $label = $this['trueLabel'];
             }
         } else {
             if (isset($options['false_label'])) {
                 $label = $options['false_label'];
             } else {
-                $label = $this->falseLabel();
+                $label = $this['falseLabel'];
             }
         }
 
@@ -96,10 +96,10 @@ class BooleanProperty extends AbstractProperty
     /**
      * Multiple is always false for boolean property.
      *
-     * @see AbstractProperty::multiple()
+     * @see AbstractProperty::getMultiple()
      * @return boolean
      */
-    public function multiple()
+    public function getMultiple()
     {
         return false;
     }
@@ -117,7 +117,7 @@ class BooleanProperty extends AbstractProperty
     /**
      * @return Translation
      */
-    public function trueLabel()
+    public function getTrueLabel()
     {
         if ($this->trueLabel === null) {
             // Default value
@@ -139,7 +139,7 @@ class BooleanProperty extends AbstractProperty
     /**
      * @return Translation
      */
-    public function falseLabel()
+    public function getFalseLabel()
     {
         if ($this->falseLabel === null) {
             // Default value
@@ -184,12 +184,12 @@ class BooleanProperty extends AbstractProperty
         $val = $this->val();
         return [
             [
-                'label'    => $this->trueLabel(),
+                'label'    => $this['trueLabel'],
                 'selected' => !!$val,
                 'value'    => 1
             ],
             [
-                'label'    => $this->falseLabel(),
+                'label'    => $this['falseLabel'],
                 'selected' => !$val,
                 'value'    => 0
             ]

--- a/src/Charcoal/Property/ColorProperty.php
+++ b/src/Charcoal/Property/ColorProperty.php
@@ -41,7 +41,7 @@ class ColorProperty extends AbstractProperty
     /**
      * @return boolean
      */
-    public function supportAlpha()
+    public function getSupportAlpha()
     {
         return $this->supportAlpha;
     }
@@ -57,7 +57,7 @@ class ColorProperty extends AbstractProperty
     public function parseOne($val)
     {
         if ($val === null || $val === '') {
-            if ($this->allowNull()) {
+            if ($this['allowNull']) {
                 return null;
             } else {
                 throw new InvalidArgumentException(
@@ -102,11 +102,11 @@ class ColorProperty extends AbstractProperty
     public function sqlType()
     {
         // Multiple strings are always stored as TEXT because they can hold multiple values
-        if ($this->multiple()) {
+        if ($this['multiple']) {
             return 'TEXT';
         }
 
-        if ($this->supportAlpha()) {
+        if ($this['supportAlpha']) {
             return 'VARCHAR(32)';
         } else {
             return 'CHAR(7)';

--- a/src/Charcoal/Property/DateTimeProperty.php
+++ b/src/Charcoal/Property/DateTimeProperty.php
@@ -65,10 +65,10 @@ class DateTimeProperty extends AbstractProperty
     /**
      * Multiple is always false for DateTime property.
      *
-     * @see AbstractProperty::multiple()
+     * @see AbstractProperty::getMultiple()
      * @return boolean
      */
-    public function multiple()
+    public function getMultiple()
     {
         return false;
     }
@@ -121,7 +121,7 @@ class DateTimeProperty extends AbstractProperty
         if ($val instanceof DateTimeInterface) {
             return $val->format('Y-m-d H:i:s');
         } else {
-            if ($this->allowNull()) {
+            if ($this['allowNull']) {
                 return null;
             } else {
                 throw new Exception(

--- a/src/Charcoal/Property/FileProperty.php
+++ b/src/Charcoal/Property/FileProperty.php
@@ -124,7 +124,7 @@ class FileProperty extends AbstractProperty
      *
      * @return boolean
      */
-    public function publicAccess()
+    public function getPublicAccess()
     {
         return $this->publicAccess;
     }
@@ -159,7 +159,7 @@ class FileProperty extends AbstractProperty
      *
      * @return string
      */
-    public function uploadPath()
+    public function getUploadPath()
     {
         return $this->uploadPath;
     }
@@ -182,7 +182,7 @@ class FileProperty extends AbstractProperty
      *
      * @return boolean
      */
-    public function overwrite()
+    public function getOverwrite()
     {
         return $this->overwrite;
     }
@@ -403,7 +403,7 @@ class FileProperty extends AbstractProperty
      */
     public function validateMaxFilesize()
     {
-        $maxFilesize = $this->maxFilesize();
+        $maxFilesize = $this['maxFilesize'];
         if ($maxFilesize == 0) {
             // No max size rule = always true
             return true;
@@ -429,7 +429,7 @@ class FileProperty extends AbstractProperty
     public function sqlType()
     {
         // Multiple strings are always stored as TEXT because they can hold multiple values
-        if ($this->multiple()) {
+        if ($this['multiple']) {
             return 'TEXT';
         } else {
             return 'VARCHAR(255)';
@@ -463,7 +463,7 @@ class FileProperty extends AbstractProperty
         ) {
             $file = $_FILES[$i];
 
-            if (is_array($file['name']) && $this->multiple() && $this->l10n()) {
+            if (is_array($file['name']) && $this['multiple'] && $this['l10n']) {
                 $f = [];
                 foreach ($file['name'] as $lang => $langVal) {
                     $f[$lang] = [];
@@ -484,7 +484,7 @@ class FileProperty extends AbstractProperty
                         $f[$lang][] = $this->fileUpload($data);
                     }
                 }
-            } elseif (is_array($file['name']) && $this->multiple()) {
+            } elseif (is_array($file['name']) && $this['multiple']) {
                 $f = [];
                 $k = 0;
                 $total = count($file['name']);
@@ -498,7 +498,7 @@ class FileProperty extends AbstractProperty
 
                     $f[] = $this->fileUpload($data);
                 }
-            } elseif (is_array($file['name']) && $this->l10n()) {
+            } elseif (is_array($file['name']) && $this['l10n']) {
                 // Not so cool
                 // Both the multiple and l10n loop could and
                 // should be combined into one.
@@ -529,7 +529,7 @@ class FileProperty extends AbstractProperty
         // Check in vals for data: base64 images
         // val should be an array if multiple...
         if ($val !== null) {
-            if ($this->l10n()) {
+            if ($this['l10n']) {
                 $l10nVal = ($val instanceof Translation) ? $val->data() : $val;
 
                 $f = [];
@@ -542,7 +542,7 @@ class FileProperty extends AbstractProperty
                 if (!empty($f)) {
                     return $f;
                 }
-            } elseif ($this->multiple()) {
+            } elseif ($this['multiple']) {
                 $f = [];
                 foreach ($val as $v) {
                     if ((is_array($v) && isset($v['id'])) || $this->isDataUri($v)) {

--- a/src/Charcoal/Property/GenericProperty.php
+++ b/src/Charcoal/Property/GenericProperty.php
@@ -26,7 +26,7 @@ class GenericProperty extends AbstractProperty
      */
     public function sqlType()
     {
-        if ($this->multiple()) {
+        if ($this['multiple']) {
             return 'TEXT';
         } else {
             return 'VARCHAR(255)';

--- a/src/Charcoal/Property/HtmlProperty.php
+++ b/src/Charcoal/Property/HtmlProperty.php
@@ -31,7 +31,7 @@ class HtmlProperty extends StringProperty
     /**
      * @return string
      */
-    public function filesystem()
+    public function getFilesystem()
     {
         return $this->filesystem;
     }
@@ -64,7 +64,7 @@ class HtmlProperty extends StringProperty
      * @see StringProperty::allowHtml()
      * @return boolean
      */
-    public function allowHtml()
+    public function getAllowHtml()
     {
         return true;
     }

--- a/src/Charcoal/Property/IdProperty.php
+++ b/src/Charcoal/Property/IdProperty.php
@@ -68,10 +68,10 @@ class IdProperty extends AbstractProperty
     /**
      * Multiple is always FALSE for ID property.
      *
-     * @see    AbstractProperty::multiple()
+     * @see    AbstractProperty::getMultiple()
      * @return boolean
      */
-    public function multiple()
+    public function getMultiple()
     {
         return false;
     }
@@ -101,10 +101,10 @@ class IdProperty extends AbstractProperty
     /**
      * L10N is always FALSE for ID property.
      *
-     * @see    AbstractProperty::l10n()
+     * @see    AbstractProperty::getL10n()
      * @return boolean
      */
-    public function l10n()
+    public function getL10n()
     {
         return false;
     }
@@ -151,7 +151,7 @@ class IdProperty extends AbstractProperty
      *
      * @return string
      */
-    public function mode()
+    public function getMode()
     {
         return $this->mode;
     }
@@ -190,7 +190,7 @@ class IdProperty extends AbstractProperty
      */
     public function autoGenerate()
     {
-        $mode = $this->mode();
+        $mode = $this['mode'];
 
         if ($mode === self::MODE_UNIQID) {
             return uniqid();
@@ -238,7 +238,7 @@ class IdProperty extends AbstractProperty
      */
     public function sqlExtra()
     {
-        $mode = $this->mode();
+        $mode = $this->getMode();
 
         if ($mode === self::MODE_AUTO_INCREMENT) {
             return 'AUTO_INCREMENT';
@@ -260,7 +260,7 @@ class IdProperty extends AbstractProperty
      */
     public function sqlType()
     {
-        $mode = $this->mode();
+        $mode = $this->getMode();
 
         if ($mode === self::MODE_AUTO_INCREMENT) {
             $dbDriver = $this->pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
@@ -286,7 +286,7 @@ class IdProperty extends AbstractProperty
      */
     public function sqlPdoType()
     {
-        $mode = $this->mode();
+        $mode = $this->getMode();
 
         if ($mode === self::MODE_AUTO_INCREMENT) {
             return PDO::PARAM_INT;

--- a/src/Charcoal/Property/IpProperty.php
+++ b/src/Charcoal/Property/IpProperty.php
@@ -59,10 +59,10 @@ class IpProperty extends AbstractProperty
     /**
      * Multiple is always FALSE for ID property.
      *
-     * @see    AbstractProperty::multiple()
+     * @see    AbstractProperty::getMultiple()
      * @return boolean
      */
-    public function multiple()
+    public function getMultiple()
     {
         return false;
     }
@@ -91,10 +91,10 @@ class IpProperty extends AbstractProperty
     /**
      * L10N is always FALSE for IP property.
      *
-     * @see    AbstractProperty::l10n()
+     * @see    AbstractProperty::getL10n()
      * @return boolean
      */
-    public function l10n()
+    public function getL10n()
     {
         return false;
     }
@@ -122,7 +122,7 @@ class IpProperty extends AbstractProperty
     /**
      * @return string
      */
-    public function storageMode()
+    public function getStorageMode()
     {
         return $this->storageMode;
     }
@@ -166,7 +166,7 @@ class IpProperty extends AbstractProperty
      */
     public function storageVal($val)
     {
-        $mode = $this->storageMode();
+        $mode = $this->getStorageMode();
 
         if ($mode === self::STORAGE_MODE_INT) {
             return $this->intVal($val);
@@ -194,7 +194,7 @@ class IpProperty extends AbstractProperty
      */
     public function sqlType()
     {
-        $mode = $this->storageMode();
+        $mode = $this->getStorageMode();
 
         if ($mode === self::STORAGE_MODE_INT) {
             return 'BIGINT';
@@ -209,7 +209,7 @@ class IpProperty extends AbstractProperty
      */
     public function sqlPdoType()
     {
-        $mode = $this->storageMode();
+        $mode = $this->getStorageMode();
 
         if ($mode === self::STORAGE_MODE_INT) {
             return PDO::PARAM_INT;

--- a/src/Charcoal/Property/LangProperty.php
+++ b/src/Charcoal/Property/LangProperty.php
@@ -169,7 +169,7 @@ class LangProperty extends AbstractProperty implements SelectablePropertyInterfa
         }
 
         /** Parse multilingual values */
-        if ($this->l10n()) {
+        if ($this['l10n']) {
             $propertyValue = $this->l10nVal($val, $options);
             if ($propertyValue === null) {
                 return '';
@@ -183,7 +183,7 @@ class LangProperty extends AbstractProperty implements SelectablePropertyInterfa
         $separator = $this->multipleSeparator();
 
         /** Parse multiple values / ensure they are of array type. */
-        if ($this->multiple()) {
+        if ($this['multiple']) {
             if (!is_array($propertyValue)) {
                 $propertyValue = explode($separator, $propertyValue);
             }
@@ -222,7 +222,7 @@ class LangProperty extends AbstractProperty implements SelectablePropertyInterfa
      */
     public function sqlType()
     {
-        if ($this->multiple()) {
+        if ($this['multiple']) {
             return 'TEXT';
         }
 

--- a/src/Charcoal/Property/ModelStructureProperty.php
+++ b/src/Charcoal/Property/ModelStructureProperty.php
@@ -388,7 +388,7 @@ class ModelStructureProperty extends StructureProperty
     public function structureVal($val, $options = [])
     {
         if ($val === null) {
-            return ($this->multiple() ? [] : null);
+            return ($this['multiple'] ? [] : null);
         }
 
         $metadata = clone $this->structureMetadata();
@@ -424,7 +424,7 @@ class ModelStructureProperty extends StructureProperty
 
         $val = $this->parseVal($val);
 
-        if ($this->multiple()) {
+        if ($this['multiple']) {
             $entries = [];
             foreach ($val as $v) {
                 $entries[] = $this->createStructureModelWith($metadata, $defaultData, $v);
@@ -479,7 +479,7 @@ class ModelStructureProperty extends StructureProperty
     {
         $val = parent::save($val);
 
-        if ($this->multiple()) {
+        if ($this['multiple']) {
             $proto = $this->structureProto();
             if ($proto instanceof ModelInterface) {
                 $objs = (array)$this->structureVal($val);

--- a/src/Charcoal/Property/NumberProperty.php
+++ b/src/Charcoal/Property/NumberProperty.php
@@ -109,7 +109,7 @@ class NumberProperty extends AbstractProperty
     public function sqlType()
     {
         // Multiple number are stocked as TEXT because we do not know the maximum length
-        if ($this->multiple()) {
+        if ($this['multiple']) {
             return 'TEXT';
         }
 

--- a/src/Charcoal/Property/ObjectProperty.php
+++ b/src/Charcoal/Property/ObjectProperty.php
@@ -149,7 +149,7 @@ class ObjectProperty extends AbstractProperty implements SelectablePropertyInter
      * @throws RuntimeException If the object type was not previously set.
      * @return string
      */
-    public function objType()
+    public function getObjType()
     {
         if ($this->objType === null) {
             throw new RuntimeException(sprintf(
@@ -182,7 +182,7 @@ class ObjectProperty extends AbstractProperty implements SelectablePropertyInter
     /**
      * @return string
      */
-    public function pattern()
+    public function getPattern()
     {
         return $this->pattern;
     }
@@ -193,7 +193,7 @@ class ObjectProperty extends AbstractProperty implements SelectablePropertyInter
      */
     public function sqlType()
     {
-        if ($this->multiple() === true) {
+        if ($this['multiple'] === true) {
             return 'TEXT';
         } else {
             // Read from proto's key
@@ -209,7 +209,7 @@ class ObjectProperty extends AbstractProperty implements SelectablePropertyInter
      */
     public function sqlPdoType()
     {
-        if ($this->multiple() === true) {
+        if ($this['multiple'] === true) {
             return PDO::PARAM_STR;
         } else {
             // Read from proto's key
@@ -250,7 +250,7 @@ class ObjectProperty extends AbstractProperty implements SelectablePropertyInter
 
         $val = $this->parseVal($val);
 
-        if ($this->multiple()) {
+        if ($this['multiple']) {
             if (is_array($val)) {
                 $val = implode($this->multipleSeparator(), $val);
             }
@@ -270,7 +270,7 @@ class ObjectProperty extends AbstractProperty implements SelectablePropertyInter
      */
     public function proto()
     {
-        return $this->modelFactory()->get($this->objType());
+        return $this->modelFactory()->get($this['objType']);
     }
 
     /**
@@ -292,7 +292,7 @@ class ObjectProperty extends AbstractProperty implements SelectablePropertyInter
 
         $val = $this->parseVal($val);
 
-        if ($this->multiple()) {
+        if ($this['multiple']) {
             if (is_array($val)) {
                 $val = implode($this->multipleSeparator(), $val);
             }
@@ -339,7 +339,7 @@ class ObjectProperty extends AbstractProperty implements SelectablePropertyInter
         }
 
         /** Parse multilingual values */
-        if ($this->l10n()) {
+        if ($this['l10n']) {
             $propertyValue = $this->l10nVal($val, $options);
             if ($propertyValue === null) {
                 return '';
@@ -353,7 +353,7 @@ class ObjectProperty extends AbstractProperty implements SelectablePropertyInter
         $separator = $this->multipleSeparator();
 
         /** Parse multiple values / ensure they are of array type. */
-        if ($this->multiple()) {
+        if ($this['multiple']) {
             if (!is_array($propertyValue)) {
                 $propertyValue = explode($separator, $propertyValue);
             }
@@ -757,7 +757,7 @@ class ObjectProperty extends AbstractProperty implements SelectablePropertyInter
     protected function renderObjPattern(ModelInterface $obj, $pattern = null, $lang = null)
     {
         if ($pattern === null) {
-            $pattern = $this->pattern();
+            $pattern = $this->getPattern();
         } elseif (!is_string($pattern)) {
             throw new InvalidArgumentException(
                 'The render pattern must be a string.'
@@ -829,7 +829,7 @@ class ObjectProperty extends AbstractProperty implements SelectablePropertyInter
     protected function modelLoader($objType = null)
     {
         if ($objType === null) {
-            $objType = $this->objType();
+            $objType = $this->getObjType();
         } elseif (!is_string($objType)) {
             throw new InvalidArgumentException(
                 'Object type must be a string.'

--- a/src/Charcoal/Property/PropertyInterface.php
+++ b/src/Charcoal/Property/PropertyInterface.php
@@ -26,7 +26,7 @@ interface PropertyInterface
      *
      * @return string
      */
-    public function ident();
+    public function getIdent();
 
     /**
      * Retrieve the property's localized identifier.
@@ -72,7 +72,7 @@ interface PropertyInterface
     /**
      * @return mixed
      */
-    public function label();
+    public function getLabel();
 
     /**
      * @param boolean $l10n The l10n, or "translatable" flag.
@@ -83,7 +83,7 @@ interface PropertyInterface
     /**
      * @return boolean
      */
-    public function l10n();
+    public function getL10n();
 
     /**
      * @param boolean $hidden The hidden flag.
@@ -94,7 +94,7 @@ interface PropertyInterface
     /**
      * @return boolean
      */
-    public function hidden();
+    public function getHidden();
 
     /**
      * @param boolean $multiple The multiple flag.
@@ -105,7 +105,7 @@ interface PropertyInterface
     /**
      * @return boolean
      */
-    public function multiple();
+    public function getMultiple();
 
     /**
      * Set the multiple options / configuration, when property is `multiple`.
@@ -123,7 +123,7 @@ interface PropertyInterface
     /**
      * @return array
      */
-    public function multipleOptions();
+    public function getMultipleOptions();
 
     /**
      * @param boolean $required The property required flag.
@@ -134,7 +134,7 @@ interface PropertyInterface
     /**
      * @return boolean
      */
-    public function required();
+    public function getRequired();
 
     /**
      * @param boolean $unique The property unique flag.
@@ -145,7 +145,7 @@ interface PropertyInterface
     /**
      * @return boolean
      */
-    public function unique();
+    public function getUnique();
 
     /**
      * @param boolean $storable The property storable flag.
@@ -156,7 +156,7 @@ interface PropertyInterface
     /**
      * @return boolean
      */
-    public function storable();
+    public function getStorable();
 
     /**
      * @param boolean $active The property active flag. Inactive properties should have no effects.
@@ -167,7 +167,7 @@ interface PropertyInterface
     /**
      * @return boolean
      */
-    public function active();
+    public function getActive();
 
     /**
      * @param mixed $val The value, at time of saving.

--- a/src/Charcoal/Property/SpriteProperty.php
+++ b/src/Charcoal/Property/SpriteProperty.php
@@ -63,7 +63,7 @@ class SpriteProperty extends AbstractProperty implements SelectablePropertyInter
     /**
      * @return string
      */
-    public function sprite()
+    public function getSprite()
     {
         return $this->sprite;
     }
@@ -96,7 +96,7 @@ class SpriteProperty extends AbstractProperty implements SelectablePropertyInter
     public function sqlType()
     {
         // Multiple strings are always stored as TEXT because they can hold multiple values
-        if ($this->multiple()) {
+        if ($this['multiple']) {
             return 'TEXT';
         }
 
@@ -119,7 +119,7 @@ class SpriteProperty extends AbstractProperty implements SelectablePropertyInter
      */
     public function buildChoicesFromSprite()
     {
-        $sprite = $this->sprite();
+        $sprite = $this['sprite'];
 
         if (!file_exists($sprite)) {
             return [];
@@ -159,7 +159,7 @@ class SpriteProperty extends AbstractProperty implements SelectablePropertyInter
             $val = $this->view->render(
                 '<svg fill="currentColor" viewBox="0 0 25 25" height="40px" role=\'img\'><use xlink:href=\'{{# withBaseUrl }}{{ spritePathWithHash }}{{/ withBaseUrl }}\'></use></svg>',
                 [
-                    'spritePathWithHash' => $this->sprite().'#'.$val
+                    'spritePathWithHash' => $this->getSprite().'#'.$val
                 ]
             );
         }
@@ -177,7 +177,7 @@ class SpriteProperty extends AbstractProperty implements SelectablePropertyInter
             $val = $this->view->render(
                 '{{# withBaseUrl }}{{ spritePathWithHash }}{{/ withBaseUrl }}',
                 [
-                    'spritePathWithHash' => $this->sprite().'#'.$val
+                    'spritePathWithHash' => $this->getSprite().'#'.$val
                 ]
             );
         }
@@ -216,7 +216,7 @@ class SpriteProperty extends AbstractProperty implements SelectablePropertyInter
             $choice = [
                 'value'              => $choiceIdent,
                 'label'              => $this->translator()->translation($choiceIdent),
-                'spritePathWithHash' => $this->sprite().'#'.$choice
+                'spritePathWithHash' => $this['sprite'].'#'.$choice
             ];
         } elseif (is_array($choice)) {
             if (!isset($choice['value'])) {
@@ -224,11 +224,11 @@ class SpriteProperty extends AbstractProperty implements SelectablePropertyInter
             }
 
             if (!isset($choice['spritePathWithHash'])) {
-                $choice['spritePathWithHash'] = (string)$this->sprite().'#'.$choiceIdent;
+                $choice['spritePathWithHash'] = (string)$this['sprite'].'#'.$choiceIdent;
             }
 
             if (!isset($choice['spritePathWithHash'])) {
-                $choice['spritePathWithHash'] = (string)$this->sprite().'#'.$choiceIdent;
+                $choice['spritePathWithHash'] = (string)$this['sprite'].'#'.$choiceIdent;
                 $choice['label']              = $this->translator()->translation($choiceIdent);
             }
         } else {

--- a/src/Charcoal/Property/StorablePropertyTrait.php
+++ b/src/Charcoal/Property/StorablePropertyTrait.php
@@ -85,7 +85,7 @@ trait StorablePropertyTrait
     public function fieldNames()
     {
         $fields = [];
-        if ($this->l10n()) {
+        if ($this['l10n']) {
             foreach ($this->translator()->availableLocales() as $langCode) {
                 $fields[$langCode] = $this->l10nIdent($langCode);
             }
@@ -109,11 +109,11 @@ trait StorablePropertyTrait
             return null;
         }
 
-        if (!$this->l10n() && $val instanceof Translation) {
+        if (!$this['l10n'] && $val instanceof Translation) {
             $val = (string)$val;
         }
 
-        if ($this->multiple()) {
+        if ($this['multiple']) {
             if (is_array($val)) {
                 $val = implode($this->multipleSeparator(), $val);
             }
@@ -147,7 +147,7 @@ trait StorablePropertyTrait
     /**
      * @return string
      */
-    abstract public function ident();
+    abstract public function getIdent();
 
     /**
      * @param  string|null $lang The language code to return the identifier with.
@@ -158,12 +158,12 @@ trait StorablePropertyTrait
     /**
      * @return boolean
      */
-    abstract public function l10n();
+    abstract public function getL10n();
 
     /**
      * @return boolean
      */
-    abstract public function multiple();
+    abstract public function getMultiple();
 
     /**
      * @return string
@@ -173,7 +173,7 @@ trait StorablePropertyTrait
     /**
      * @return boolean
      */
-    abstract public function allowNull();
+    abstract public function getAllowNull();
 
     /**
      * @param  array $data Optional. Field data.
@@ -209,7 +209,7 @@ trait StorablePropertyTrait
             return $this->generateFields($val);
         }
 
-        if ($this->l10n()) {
+        if ($this['l10n']) {
             foreach ($this->translator()->availableLocales() as $langCode) {
                 $this->fields[$langCode]->setVal($this->fieldVal($langCode, $val));
             }
@@ -229,7 +229,7 @@ trait StorablePropertyTrait
     private function generateFields($val)
     {
         $this->fields = [];
-        if ($this->l10n()) {
+        if ($this['l10n']) {
             foreach ($this->translator()->availableLocales() as $langCode) {
                 $ident = $this->l10nIdent($langCode);
                 $field = $this->createPropertyField([
@@ -240,7 +240,7 @@ trait StorablePropertyTrait
                     'extra'       => $this->sqlExtra(),
                     'val'         => $this->fieldVal($langCode, $val),
                     'defaultVal'  => null,
-                    'allowNull'   => $this->allowNull()
+                    'allowNull'   => $this['allowNull']
                 ]);
                 $this->fields[$langCode] = $field;
             }
@@ -253,7 +253,7 @@ trait StorablePropertyTrait
                 'extra'       => $this->sqlExtra(),
                 'val'         => $this->storageVal($val),
                 'defaultVal'  => null,
-                'allowNull'   => $this->allowNull()
+                'allowNull'   => $this['allowNull']
             ]);
             $this->fields[] = $field;
         }

--- a/src/Charcoal/Property/StringProperty.php
+++ b/src/Charcoal/Property/StringProperty.php
@@ -81,7 +81,7 @@ class StringProperty extends AbstractProperty implements SelectablePropertyInter
         }
 
         /** Parse multilingual values */
-        if ($this->l10n()) {
+        if ($this['l10n']) {
             $propertyValue = $this->l10nVal($val, $options);
             if ($propertyValue === null) {
                 return '';
@@ -95,7 +95,7 @@ class StringProperty extends AbstractProperty implements SelectablePropertyInter
         $separator = $this->multipleSeparator();
 
         /** Parse multiple values / ensure they are of array type. */
-        if ($this->multiple()) {
+        if ($this['multiple']) {
             if (!is_array($propertyValue)) {
                 $propertyValue = explode($separator, $propertyValue);
             }
@@ -148,7 +148,7 @@ class StringProperty extends AbstractProperty implements SelectablePropertyInter
      *
      * @return integer
      */
-    public function maxLength()
+    public function getMaxLength()
     {
         if ($this->maxLength === null) {
             $this->maxLength = $this->defaultMaxLength();
@@ -198,7 +198,7 @@ class StringProperty extends AbstractProperty implements SelectablePropertyInter
      *
      * @return integer
      */
-    public function minLength()
+    public function getMinLength()
     {
         if ($this->minLength === null) {
             $this->minLength = $this->defaultMinLength();
@@ -242,7 +242,7 @@ class StringProperty extends AbstractProperty implements SelectablePropertyInter
      *
      * @return string
      */
-    public function regexp()
+    public function getRegexp()
     {
         if ($this->regexp === null) {
             $this->regexp = self::DEFAULT_REGEXP;
@@ -269,7 +269,7 @@ class StringProperty extends AbstractProperty implements SelectablePropertyInter
      *
      * @return boolean
      */
-    public function allowEmpty()
+    public function getAllowEmpty()
     {
         return $this->allowEmpty;
     }
@@ -290,7 +290,7 @@ class StringProperty extends AbstractProperty implements SelectablePropertyInter
     /**
      * @return boolean
      */
-    public function allowHtml()
+    public function getAllowHtml()
     {
         return $this->allowHtml;
     }
@@ -339,11 +339,11 @@ class StringProperty extends AbstractProperty implements SelectablePropertyInter
     {
         $val = $this->val();
 
-        if ($val === null && $this->allowNull()) {
+        if ($val === null && $this['allowNull']) {
             return true;
         }
 
-        $maxLength = $this->maxLength();
+        $maxLength = $this->getMaxLength();
         if ($maxLength == 0) {
             return true;
         }
@@ -378,15 +378,15 @@ class StringProperty extends AbstractProperty implements SelectablePropertyInter
         $val = $this->val();
 
         if ($val === null) {
-            return $this->allowNull();
+            return $this['allowNull'];
         }
 
-        $minLength = $this->minLength();
+        $minLength = $this['minLength'];
         if ($minLength == 0) {
             return true;
         }
 
-        if ($val === '' && $this->allowEmpty()) {
+        if ($val === '' && $this['allowEmpty']) {
             // Don't check empty string if they are allowed
             return true;
         }
@@ -419,7 +419,7 @@ class StringProperty extends AbstractProperty implements SelectablePropertyInter
     {
         $val = $this->val();
 
-        $regexp = $this->regexp();
+        $regexp = $this['regexp'];
         if ($regexp == '') {
             return true;
         }
@@ -441,7 +441,7 @@ class StringProperty extends AbstractProperty implements SelectablePropertyInter
     {
         $val = $this->val();
 
-        if (($val === null || $val === '') && !$this->allowEmpty()) {
+        if (($val === null || $val === '') && !$this['allowEmpty']) {
             return false;
         } else {
             return true;
@@ -479,11 +479,11 @@ class StringProperty extends AbstractProperty implements SelectablePropertyInter
     public function sqlType()
     {
         // Multiple strings are always stored as TEXT because they can hold multiple values
-        if ($this->multiple()) {
+        if ($this['multiple']) {
             return 'TEXT';
         }
 
-        $maxLength = $this->maxLength();
+        $maxLength = $this['maxLength'];
         // VARCHAR or TEXT, depending on length
         if ($maxLength <= 255 && $maxLength != 0) {
             return 'VARCHAR('.$maxLength.')';

--- a/src/Charcoal/Property/StructureProperty.php
+++ b/src/Charcoal/Property/StructureProperty.php
@@ -67,10 +67,10 @@ class StructureProperty extends AbstractProperty
     /**
      * L10N is always FALSE for structure property.
      *
-     * @see    AbstractProperty::l10n()
+     * @see    AbstractProperty::getL10n()
      * @return boolean
      */
-    public function l10n()
+    public function getL10n()
     {
         return false;
     }
@@ -130,7 +130,7 @@ class StructureProperty extends AbstractProperty
     public function parseOne($val)
     {
         if ($val === null || $val === '') {
-            if ($this->allowNull()) {
+            if ($this['allowNull']) {
                 return null;
             } else {
                 throw new InvalidArgumentException(

--- a/src/Charcoal/Property/TextProperty.php
+++ b/src/Charcoal/Property/TextProperty.php
@@ -38,7 +38,7 @@ class TextProperty extends StringProperty
     /**
      * @return boolean
      */
-    public function long()
+    public function getLong()
     {
         return $this->long;
     }
@@ -63,7 +63,7 @@ class TextProperty extends StringProperty
      */
     public function sqlType()
     {
-        if ($this->long() === true) {
+        if ($this['long'] === true) {
             return 'LONGTEXT';
         } else {
             return 'TEXT';


### PR DESCRIPTION
**BREAKING** 

- Use new `getFoo()` style of getters for propertie's properties. 
- (Requires `locomotivemtl/charcoal-config` > 0.10.0)
- Keep `ident()` as shortcut for `getIdent()`, for now.
- Use ArrayAccess methods for getters.