### PR TITLE
Fix Model/Property Validation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "prefer-stable": true,
     "extra": {
         "branch-alias": {
-            "dev-master": "0.8.x-dev"
+            "dev-master": "0.9.x-dev"
         }
     },
     "require": {
@@ -30,7 +30,7 @@
         "psr/log": "^1.0",
         "psr/cache": "^1.0",
         "locomotivemtl/charcoal-config": "~0.9",
-        "locomotivemtl/charcoal-core": "~0.4",
+        "locomotivemtl/charcoal-core": "~0.5",
         "locomotivemtl/charcoal-factory": "~0.4",
         "locomotivemtl/charcoal-image": "~0.4",
         "locomotivemtl/charcoal-translator": "~0.3"

--- a/src/Charcoal/Property/AbstractProperty.php
+++ b/src/Charcoal/Property/AbstractProperty.php
@@ -291,9 +291,10 @@ abstract class AbstractProperty extends AbstractEntity implements
     /**
      * Set the property's value.
      *
+     * @deprecated
+     *
      * @param  mixed $val The property (raw) value.
      * @return self
-     * @deprecated
      */
     final public function setVal($val)
     {
@@ -303,10 +304,25 @@ abstract class AbstractProperty extends AbstractEntity implements
     }
 
     /**
+     * Clear the property's value.
+     *
+     * @deprecated
+     *
+     * @return self
+     */
+    final public function clearVal()
+    {
+        $this->val = null;
+
+        return $this;
+    }
+
+    /**
      * Retrieve the property's value.
      *
-     * @return mixed
      * @deprecated
+     *
+     * @return mixed
      */
     final public function val()
     {
@@ -840,7 +856,7 @@ abstract class AbstractProperty extends AbstractEntity implements
         return [
             'required',
             'unique',
-            'allowNull'
+            'allowNull',
         ];
     }
 
@@ -884,8 +900,6 @@ abstract class AbstractProperty extends AbstractEntity implements
 
         return true;
     }
-
-
 
     /**
      * @param mixed $val The value, at time of saving.

--- a/src/Charcoal/Property/EmailProperty.php
+++ b/src/Charcoal/Property/EmailProperty.php
@@ -36,8 +36,9 @@ class EmailProperty extends StringProperty
     public function validationMethods()
     {
         $parentMethods = parent::validationMethods();
+
         return array_merge($parentMethods, [
-            'email'
+            'email',
         ]);
     }
 

--- a/src/Charcoal/Property/FileProperty.php
+++ b/src/Charcoal/Property/FileProperty.php
@@ -369,7 +369,10 @@ class FileProperty extends AbstractProperty
     {
         $parentMethods = parent::validationMethods();
 
-        return array_merge($parentMethods, [ 'accepted_mimetypes', 'max_filesize' ]);
+        return array_merge($parentMethods, [
+            'acceptedMimetypes',
+            'maxFilesize',
+        ]);
     }
 
     /**

--- a/src/Charcoal/Property/IdProperty.php
+++ b/src/Charcoal/Property/IdProperty.php
@@ -174,6 +174,20 @@ class IdProperty extends AbstractProperty
     }
 
     /**
+     * @return boolean
+     */
+    public function validateRequired()
+    {
+        $mode = $this->getMode();
+
+        if ($mode !== self::MODE_AUTO_INCREMENT) {
+            return parent::validateRequired();
+        }
+
+        return true;
+    }
+
+    /**
      * Auto-generate a value upon first save.
      *
      * - self::MODE_AUTOINCREMENT

--- a/src/Charcoal/Property/PropertyValidator.php
+++ b/src/Charcoal/Property/PropertyValidator.php
@@ -4,9 +4,10 @@ namespace Charcoal\Property;
 
 // From 'charcoal-core'
 use Charcoal\Validator\AbstractValidator;
+use Charcoal\Validator\ValidatableInterface;
 
 /**
- *
+ * Property Validator
  */
 class PropertyValidator extends AbstractValidator
 {
@@ -15,17 +16,21 @@ class PropertyValidator extends AbstractValidator
      */
     public function validate()
     {
-        // The model, in this case, should be a PropertyInterface
-        $model = $this->model;
+        $result = true;
 
-        $ret = true;
-        $validationMethods = $model->validationMethods();
-        foreach ($validationMethods as $m) {
-            $fn = [$model, 'validate_'.$m];
-            if (is_callable($fn)) {
-                $ret = $ret && call_user_func($fn);
+        // The model, in this case, should be a PropertyInterface
+        $property = $this->model;
+
+        $methods = $property->validationMethods();
+        foreach ($methods as $method) {
+            $method = $this->camelize($method);
+
+            $func = [ $property, 'validate'.ucfirst($method) ];
+            if (is_callable($func)) {
+                $result = $result && call_user_func($func);
             }
         }
-        return $ret;
+
+        return $result;
     }
 }

--- a/src/Charcoal/Property/StringProperty.php
+++ b/src/Charcoal/Property/StringProperty.php
@@ -325,7 +325,7 @@ class StringProperty extends AbstractProperty implements SelectablePropertyInter
             'maxLength',
             'minLength',
             'regexp',
-            'allowEmpty'
+            'allowEmpty',
         ]);
     }
 

--- a/tests/Charcoal/Property/FilePropertyTest.php
+++ b/tests/Charcoal/Property/FilePropertyTest.php
@@ -135,8 +135,8 @@ class FilePropertyTest extends AbstractTestCase
     {
         $obj = $this->obj;
         $ret = $obj->validationMethods();
-        $this->assertContains('accepted_mimetypes', $ret);
-        $this->assertContains('max_filesize', $ret);
+        $this->assertContains('acceptedMimetypes', $ret);
+        $this->assertContains('maxFilesize', $ret);
     }
 
     /**


### PR DESCRIPTION
Related:
- locomotivemtl/charcoal-core#7
- locomotivemtl/charcoal-admin#31

---

Changed:
- Bumped branch-alias to 0.9

Added:
- Method `IdProperty::validateRequired()` to only validate non-incrementing values
- Method `AbstractProperty::clearVal()` to purge any value from deprecated class property `$value`

Fixed:
- Property validation method names
- Camelizing of property validation methods