### PR TITLE
Add support for custom storable property fields

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "prefer-stable": true,
     "extra": {
         "branch-alias": {
-            "dev-master": "0.9.x-dev"
+            "dev-master": "0.10.x-dev"
         }
     },
     "require": {
@@ -30,7 +30,7 @@
         "psr/log": "^1.0",
         "psr/cache": "^1.0",
         "locomotivemtl/charcoal-config": "~0.9",
-        "locomotivemtl/charcoal-core": "~0.5",
+        "locomotivemtl/charcoal-core": "~0.6",
         "locomotivemtl/charcoal-factory": "~0.4",
         "locomotivemtl/charcoal-image": "~0.4",
         "locomotivemtl/charcoal-translator": "~0.3"

--- a/metadata/charcoal/property/audio-property.json
+++ b/metadata/charcoal/property/audio-property.json
@@ -1,13 +1,13 @@
 {
-    "property":{
-        "min_length":{
+    "property": {
+        "min_length": {
             "type": "number",
             "label": "Minimum length",
             "description": "Minimum audio length, in seconds. If 0, empty or null, then there is no minimal constraint.",
             "notes": "In seconds",
             "allow_null": true
         },
-        "max_length":{
+        "max_length": {
             "type": "number",
             "label": "Maximum length",
             "description": "Maximum audio length, in seconds. If 0, empty or null, then there is no maximal constraint.",

--- a/metadata/charcoal/property/boolean-property.json
+++ b/metadata/charcoal/property/boolean-property.json
@@ -7,10 +7,10 @@
         },
         "false_label": {
             "type": "string",
-            "label":"Label, for \"false\" value.",
+            "label": "Label, for \"false\" value.",
             "l10n": true
         },
-        "multiple":{
+        "multiple": {
             "active": false,
             "description": "Boolean properties can not be multiple (will always be false)."
         }

--- a/metadata/charcoal/property/file-property.json
+++ b/metadata/charcoal/property/file-property.json
@@ -5,7 +5,7 @@
             "label": "File System",
             "description": "The default file system where the uploaded files will be stored."
         },
-        "public_access":{
+        "public_access": {
             "type": "boolean",
             "label": "Public access?",
             "description": "If the public access is true (default) then the file will be stored in a public filesystem. If not, then it will be stored in a private (non-web-accessible) filesystem."

--- a/metadata/charcoal/property/image-property.json
+++ b/metadata/charcoal/property/image-property.json
@@ -1,11 +1,11 @@
 {
     "properties": {
-        "driver_type":{
-            "label":"Image driver",
+        "driver_type": {
+            "label": "Image Driver",
             "type": "text",
-            "choices":{
-                "imagick":{},
-                "imagemagick":{}
+            "choices": {
+                "imagick": {},
+                "imagemagick": {}
             }
         },
         "effects": {

--- a/metadata/charcoal/property/ip-property.json
+++ b/metadata/charcoal/property/ip-property.json
@@ -1,10 +1,10 @@
 {
-    "properties":{
-        "storage_mode":{
+    "properties": {
+        "storage_mode": {
             "type": "text",
-            "choices":{
-                "string":{},
-                "int":{}
+            "choices": {
+                "string": {},
+                "int": {}
             }
         }
     }

--- a/metadata/charcoal/property/number-property.json
+++ b/metadata/charcoal/property/number-property.json
@@ -1,12 +1,12 @@
 {
-    "properties":{
-        "min":{
-            "type":"number",
-            "allow_null":true
+    "properties": {
+        "min": {
+            "type": "number",
+            "allow_null": true
         },
-        "max":{
-            "type":"number",
-            "allow_null":true
+        "max": {
+            "type": "number",
+            "allow_null": true
         }
     }
 }

--- a/metadata/charcoal/property/object-property.json
+++ b/metadata/charcoal/property/object-property.json
@@ -1,13 +1,13 @@
 {
-    "properties":{
-        "obj_type":{
-            "type":"string",
-            "label":"Object type"
+    "properties": {
+        "obj_type": {
+            "type": "string",
+            "label": "Object Type"
         },
-        "pattern":{
-            "type":"string",
-            "label":"Render pattern",
-            "description":"When attempting to render the object, it will use the following pattern to render. Defaults to \"{{name}}\"."
+        "pattern": {
+            "type": "string",
+            "label": "Render Pattern",
+            "description": "When attempting to render the object, it will use the following pattern to render. Defaults to \"{{name}}\"."
         }
     }
 }

--- a/metadata/charcoal/property/property-interface.json
+++ b/metadata/charcoal/property/property-interface.json
@@ -1,53 +1,57 @@
 {
-    "properties":{
-        "ident":{
+    "properties": {
+        "ident": {
             "type": "string"
         },
-        "label":{
+        "label": {
             "type": "string",
             "label": "Label",
             "l10n": true
         },
-        "description":{
+        "description": {
             "type": "html",
             "label": "Description",
             "l10n": true
         },
-        "notes":{
+        "notes": {
             "type": "html",
             "label": "Notes",
             "l10n": true
         },
-        "l10n":{
+        "l10n": {
             "type": "boolean",
             "label": "Translatable (l10n)?",
             "description": "L10n properties (defaults to false) allow the value to be localized / translatable. In storage, a field will be create for each active languages."
         },
-        "multiple":{
+        "multiple": {
             "type": "boolean",
             "label": "Multiple?",
             "description": "Multiple properties (default to false) can hold an array of values, instead of just a single value."
         },
-        "hidden":{
+        "hidden": {
             "type": "boolean",
             "label": "Hidden?",
             "description": "Hidden properties (default to false) should be active but hidden from any UI."
         },
-        "required":{
+        "allow_null": {
+            "type": "boolean",
+            "label": "Allow Null?"
+        },
+        "required": {
             "type": "boolean",
             "label": "Required?"
         },
-        "unique":{
+        "unique": {
             "type": "boolean",
             "label": "Unique?",
             "description": "Unique properties (default to false) can not have two of the same value in the same storage / database."
         },
-        "storable":{
+        "storable": {
             "type": "boolean",
             "label": "Storable?",
             "description": "Storable properties (default to true) should have a space in the database to be stored. Non-storable properties (if set to false) "
         },
-        "active":{
+        "active": {
             "type": "boolean",
             "label": "Active?",
             "description": "Only active properties (default to true) should be taken into consideration. Inactive properties should not be used anywhere."

--- a/metadata/charcoal/property/sprite-property.json
+++ b/metadata/charcoal/property/sprite-property.json
@@ -1,8 +1,8 @@
 {
-    "properties":{
-        "sprite":{
-            "type":"string",
-            "label":"Sprite path"
+    "properties": {
+        "sprite": {
+            "type": "string",
+            "label": "Sprite Path"
         }
     }
 }

--- a/metadata/charcoal/property/string-property.json
+++ b/metadata/charcoal/property/string-property.json
@@ -8,7 +8,7 @@
         },
         "max_length": {
             "type": "number",
-            "label":"Maximum length",
+            "label": "Maximum length",
             "description": "Maximum length (or number of characters) constraint. UTF-8 characters are supported. If 0, empty or null, then it should be ignored (no maximal constraint).",
             "allow_null": true
         },
@@ -16,11 +16,11 @@
             "type": "string",
             "label": "Regular expression",
             "description": "Regular expression validation constraint.",
-            "allow_null":true
+            "allow_null": true
         },
         "allow_empty": {
             "type": "boolean",
-            "label":"Empty string allowed?"
+            "label": "Empty string allowed?"
         }
     }
 }

--- a/src/Charcoal/Property/AbstractProperty.php
+++ b/src/Charcoal/Property/AbstractProperty.php
@@ -475,8 +475,6 @@ abstract class AbstractProperty extends AbstractEntity implements
         return (string)$propertyValue;
     }
 
-
-
     /**
      * @param mixed $label The property label.
      * @return self

--- a/src/Charcoal/Property/AbstractProperty.php
+++ b/src/Charcoal/Property/AbstractProperty.php
@@ -343,7 +343,7 @@ abstract class AbstractProperty extends AbstractEntity implements
     final public function parseVal($val)
     {
         if ($this['allowNull']) {
-            if ($val === null) {
+            if ($val === null || $val === '') {
                 return null;
             }
         } elseif ($val === null) {

--- a/src/Charcoal/Property/IdProperty.php
+++ b/src/Charcoal/Property/IdProperty.php
@@ -257,7 +257,7 @@ class IdProperty extends AbstractProperty
         if ($mode === self::MODE_AUTO_INCREMENT) {
             return 'AUTO_INCREMENT';
         } else {
-            return '';
+            return null;
         }
     }
 

--- a/src/Charcoal/Property/MultiObjectProperty.php
+++ b/src/Charcoal/Property/MultiObjectProperty.php
@@ -131,19 +131,11 @@ class MultiObjectProperty extends AbstractProperty
     }
 
     /**
-     * @return string
-     */
-    public function sqlExtra()
-    {
-        return '';
-    }
-
-    /**
-     * @return string
+     * @return string|null
      */
     public function sqlType()
     {
-        return '';
+        return null;
     }
 
     /**

--- a/src/Charcoal/Property/PropertyField.php
+++ b/src/Charcoal/Property/PropertyField.php
@@ -56,6 +56,13 @@ class PropertyField
     private $allowNull;
 
     /**
+     * Holds a list of all snake_case strings.
+     *
+     * @var string[]
+     */
+    protected static $snakeCache = [];
+
+    /**
      * @param  array $data The field data.
      * @return PropertyField Chainable
      */
@@ -104,8 +111,7 @@ class PropertyField
                 'Identifier must be a string'
             );
         }
-        // Ensure snake_case
-        $this->ident = strtolower(preg_replace('/(?<!^)[A-Z]/', '_$0', $ident));
+        $this->ident = $this->snakeize($ident);
         return $this;
     }
 
@@ -342,5 +348,26 @@ class PropertyField
         }
 
         return implode(' ', $parts);
+    }
+
+    /**
+     * Transform a string from "camelCase" to "snake_case".
+     *
+     * @param  string $value The string to snakeize.
+     * @return string The snake_case string.
+     */
+    protected function snakeize($value)
+    {
+        $key = $value;
+
+        if (isset(static::$snakeCache[$key])) {
+            return static::$snakeCache[$key];
+        }
+
+        $value = strtolower(preg_replace('/(?<!^)[A-Z]/', '_$0', $value));
+
+        static::$snakeCache[$key] = $value;
+
+        return static::$snakeCache[$key];
     }
 }

--- a/src/Charcoal/Property/PropertyField.php
+++ b/src/Charcoal/Property/PropertyField.php
@@ -5,24 +5,18 @@ namespace Charcoal\Property;
 use PDO;
 use InvalidArgumentException;
 
-// From 'charcoal-translator'
-use Charcoal\Translator\Translation;
-use Charcoal\Translator\TranslatorAwareTrait;
-
 /**
  *
  */
 class PropertyField
 {
-    use TranslatorAwareTrait;
-
     /**
      * @var string
      */
     private $ident;
 
     /**
-     * @var Translation
+     * @var string
      */
     private $label;
 
@@ -60,14 +54,6 @@ class PropertyField
      * @var boolean
      */
     private $allowNull;
-
-    /**
-     * @param array $data Constructor options.
-     */
-    public function __construct(array $data)
-    {
-        $this->setTranslator($data['translator']);
-    }
 
     /**
      * @param  array $data The field data.
@@ -115,7 +101,7 @@ class PropertyField
     {
         if (!is_string($ident)) {
             throw new InvalidArgumentException(
-                'Identifier must be a string.'
+                'Identifier must be a string'
             );
         }
         // Ensure snake_case
@@ -132,17 +118,23 @@ class PropertyField
     }
 
     /**
-     * @param  mixed $label The field label.
+     * @param  string $label The field label.
+     * @throws InvalidArgumentException If the label is not a string.
      * @return PropertyField Chainable
      */
     public function setLabel($label)
     {
-        $this->label = $this->translator()->translation($label);
+        if (!is_string($label) && $label !== null) {
+            throw new InvalidArgumentException(
+                'Label must be a string'
+            );
+        }
+        $this->label = $label;
         return $this;
     }
 
     /**
-     * @return Translation|null
+     * @return string|null
      */
     public function label()
     {
@@ -156,9 +148,9 @@ class PropertyField
      */
     public function setSqlType($sqlType)
     {
-        if (!is_string($sqlType)) {
+        if (!is_string($sqlType) && $sqlType !== null) {
             throw new InvalidArgumentException(
-                'SQL Type must be a string.'
+                'SQL Type must be a string'
             );
         }
         $this->sqlType = $sqlType;
@@ -166,7 +158,7 @@ class PropertyField
     }
 
     /**
-     * @return string|null
+     * @return string
      */
     public function sqlType()
     {
@@ -182,7 +174,7 @@ class PropertyField
     {
         if (!is_integer($sqlPdoType)) {
             throw new InvalidArgumentException(
-                'PDO Type must be an integer.'
+                'PDO Type must be an integer'
             );
         }
         $this->sqlPdoType = $sqlPdoType;
@@ -202,15 +194,15 @@ class PropertyField
     }
 
     /**
-     * @param  string $extra The extra.
+     * @param  string|null $extra The extra.
      * @throws InvalidArgumentException If the extra is not a string.
      * @return PropertyField Chainable
      */
     public function setExtra($extra)
     {
-        if (!is_string($extra)) {
+        if (!is_string($extra) && $extra !== null) {
             throw new InvalidArgumentException(
-                'Extra must be a string.'
+                'Extra must be a string'
             );
         }
         $this->extra = $extra;
@@ -232,9 +224,9 @@ class PropertyField
      */
     public function setSqlEncoding($encoding)
     {
-        if (!is_string($encoding)) {
+        if (!is_string($encoding) && $encoding !== null) {
             throw new InvalidArgumentException(
-                'Encoding must be a string.'
+                'Encoding must be a string'
             );
         }
         $this->sqlEncoding = $encoding;
@@ -304,21 +296,26 @@ class PropertyField
     }
 
     /**
-     * @return string
+     * Generates the SQL table column.
+     *
+     * @return string|null
      */
     public function sql()
     {
         $ident = $this->ident();
         if (!$ident) {
-            return '';
+            return null;
         }
-
-        $parts = [ sprintf('`%s`', $ident) ];
 
         $dataType = $this->sqlType();
-        if ($dataType) {
-            $parts[] = $dataType;
+        if (!$dataType) {
+            return null;
         }
+
+        $parts = [
+            sprintf('`%s`', $ident),
+            $dataType
+        ];
 
         if ($this->allowNull() === false) {
             $parts[] = 'NOT NULL';

--- a/src/Charcoal/Property/PropertyInterface.php
+++ b/src/Charcoal/Property/PropertyInterface.php
@@ -9,6 +9,7 @@ interface PropertyInterface
 {
     /**
      * Get the "type" (identifier) of the property.
+     *
      * @return string
      */
     public function type();
@@ -40,31 +41,30 @@ interface PropertyInterface
      * Parse the given value.
      *
      * @param  mixed $val The value to be parsed (normalized).
-     * @throws \InvalidArgumentException If the value does not match property settings.
      * @return mixed Returns the parsed value.
      */
     public function parseVal($val);
 
     /**
-     * @param mixed $val A single value to parse.
+     * @param  mixed $val A single value to parse.
      * @return mixed The parsed value.
      */
     public function parseOne($val);
 
     /**
-     * @param mixed $val Optional. The value to to convert for input.
+     * @param  mixed $val Optional. The value to to convert for input.
      * @return string
      */
     public function inputVal($val);
 
     /**
-     * @param mixed $val Optional. The value to to convert for display.
+     * @param  mixed $val Optional. The value to to convert for display.
      * @return string
      */
     public function displayVal($val);
 
     /**
-     * @param mixed $label The property label.
+     * @param  mixed $label The property label.
      * @return PropertyInterface Chainable
      */
     public function setLabel($label);
@@ -75,7 +75,7 @@ interface PropertyInterface
     public function getLabel();
 
     /**
-     * @param boolean $l10n The l10n, or "translatable" flag.
+     * @param  boolean $l10n The l10n, or "translatable" flag.
      * @return PropertyInterface Chainable
      */
     public function setL10n($l10n);
@@ -86,7 +86,7 @@ interface PropertyInterface
     public function getL10n();
 
     /**
-     * @param boolean $hidden The hidden flag.
+     * @param  boolean $hidden The hidden flag.
      * @return PropertyInterface Chainable
      */
     public function setHidden($hidden);
@@ -97,7 +97,7 @@ interface PropertyInterface
     public function getHidden();
 
     /**
-     * @param boolean $multiple The multiple flag.
+     * @param  boolean $multiple The multiple flag.
      * @return PropertyInterface Chainable
      */
     public function setMultiple($multiple);
@@ -115,7 +115,7 @@ interface PropertyInterface
      * - `min` (integer) The minimum number of values. (0 = no limit).
      * - `max` (integer) The maximum number of values. (0 = no limit).
      *
-     * @param array $multipleOptions The property multiple options.
+     * @param  array $multipleOptions The property multiple options.
      * @return PropertyInterface Chainable
      */
     public function setMultipleOptions(array $multipleOptions);
@@ -126,7 +126,18 @@ interface PropertyInterface
     public function getMultipleOptions();
 
     /**
-     * @param boolean $required The property required flag.
+     * @param  boolean $allow The property allow null flag.
+     * @return PropertyInterface Chainable
+     */
+    public function setAllowNull($allow);
+
+    /**
+     * @return boolean
+     */
+    public function getAllowNull();
+
+    /**
+     * @param  boolean $required The property required flag.
      * @return PropertyInterface Chainable
      */
     public function setRequired($required);
@@ -137,7 +148,7 @@ interface PropertyInterface
     public function getRequired();
 
     /**
-     * @param boolean $unique The property unique flag.
+     * @param  boolean $unique The property unique flag.
      * @return PropertyInterface Chainable
      */
     public function setUnique($unique);
@@ -148,7 +159,7 @@ interface PropertyInterface
     public function getUnique();
 
     /**
-     * @param boolean $storable The property storable flag.
+     * @param  boolean $storable The property storable flag.
      * @return PropertyInterface Chainable
      */
     public function setStorable($storable);
@@ -159,7 +170,7 @@ interface PropertyInterface
     public function getStorable();
 
     /**
-     * @param boolean $active The property active flag. Inactive properties should have no effects.
+     * @param  boolean $active The property active flag. Inactive properties should have no effects.
      * @return PropertyInterface Chainable
      */
     public function setActive($active);
@@ -170,7 +181,7 @@ interface PropertyInterface
     public function getActive();
 
     /**
-     * @param mixed $val The value, at time of saving.
+     * @param  mixed $val The value, at time of saving.
      * @return mixed
      */
     public function save($val);

--- a/src/Charcoal/Property/StorablePropertyInterface.php
+++ b/src/Charcoal/Property/StorablePropertyInterface.php
@@ -11,7 +11,15 @@ interface StorablePropertyInterface
      * @param  mixed $val The value to set as field value.
      * @return \Charcoal\Property\PropertyField[]
      */
-    public function fields($val);
+    public function fields($val = null);
+
+    /**
+     * Retrieve the property's identifier formatted for field names.
+     *
+     * @param  string|null $key The field key to suffix to the property identifier.
+     * @return string
+     */
+    public function fieldIdent($key = null);
 
     /**
      * @return string[]

--- a/src/Charcoal/Property/StorablePropertyInterface.php
+++ b/src/Charcoal/Property/StorablePropertyInterface.php
@@ -29,18 +29,20 @@ interface StorablePropertyInterface
     /**
      * Set the property's SQL encoding & collation.
      *
-     * @param  string $ident The encoding ident.
+     * @param  string|null $encoding The encoding identifier or SQL encoding and collation.
      * @return self
      */
-    public function setSqlEncoding($ident);
+    public function setSqlEncoding($encoding);
 
     /**
-     * @return string
+     * Retrieve the property's SQL encoding & collation.
+     *
+     * @return string|null
      */
     public function sqlEncoding();
 
     /**
-     * @return string
+     * @return string|null
      */
     public function sqlExtra();
 

--- a/src/Charcoal/Property/StorablePropertyInterface.php
+++ b/src/Charcoal/Property/StorablePropertyInterface.php
@@ -7,20 +7,21 @@ namespace Charcoal\Property;
  */
 interface StorablePropertyInterface
 {
-
     /**
      * @param  mixed $val The value to set as field value.
-     * @return array
+     * @return \Charcoal\Property\PropertyField[]
      */
     public function fields($val);
 
     /**
-     * @return array
+     * @return string[]
      */
     public function fieldNames();
 
     /**
-     * @param mixed $val Optional. The value to convert to storage value.
+     * Retrieve the property's value in a format suitable for storage.
+     *
+     * @param  mixed $val Optional. The value to convert to storage value.
      * @return mixed
      */
     public function storageVal($val);
@@ -29,7 +30,6 @@ interface StorablePropertyInterface
      * Set the property's SQL encoding & collation.
      *
      * @param  string $ident The encoding ident.
-     * @throws \InvalidArgumentException  If the identifier is not a string.
      * @return self
      */
     public function setSqlEncoding($ident);

--- a/src/Charcoal/Property/StorablePropertyTrait.php
+++ b/src/Charcoal/Property/StorablePropertyTrait.php
@@ -18,9 +18,9 @@ trait StorablePropertyTrait
     /**
      * An empty value implies that the property will inherit the table's encoding.
      *
-     * @var string
+     * @var string|null
      */
-    private $sqlEncoding = '';
+    private $sqlEncoding;
 
     /**
      * Store of the property's storage fields.
@@ -102,6 +102,10 @@ trait StorablePropertyTrait
     {
         if ($val === null) {
             // Do not json_encode NULL values
+            return null;
+        }
+
+        if ($this['allowNull'] && $val === '') {
             return null;
         }
 
@@ -206,29 +210,30 @@ trait StorablePropertyTrait
     /**
      * Set the property's SQL encoding & collation.
      *
-     * @param  string $ident The encoding ident.
+     * @param  string|null $encoding The encoding identifier or SQL encoding and collation.
      * @throws InvalidArgumentException  If the identifier is not a string.
      * @return self
      */
-    public function setSqlEncoding($ident)
+    public function setSqlEncoding($encoding)
     {
-        if (!is_string($ident)) {
+        if (!is_string($encoding) && $encoding !== null) {
             throw new InvalidArgumentException(
                 'Encoding ident needs to be string.'
             );
         }
 
-        if ($ident === 'utf8mb4') {
-            $this->sqlEncoding = 'CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci';
+        if ($encoding === 'utf8mb4') {
+            $encoding = 'CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci';
         }
 
+        $this->sqlEncoding = $encoding;
         return $this;
     }
 
     /**
-     * Retrieve the property's SQL encoding ident.
+     * Retrieve the property's SQL encoding & collation.
      *
-     * @return string
+     * @return string|null
      */
     public function sqlEncoding()
     {
@@ -236,15 +241,23 @@ trait StorablePropertyTrait
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function sqlExtra()
     {
-        return '';
+        return null;
     }
 
     /**
-     * @return string
+     * @return string|null
+     */
+    public function sqlDefaultVal()
+    {
+        return null;
+    }
+
+    /**
+     * @return string|null
      */
     abstract public function sqlType();
 

--- a/src/Charcoal/Property/StorablePropertyTrait.php
+++ b/src/Charcoal/Property/StorablePropertyTrait.php
@@ -23,11 +23,32 @@ trait StorablePropertyTrait
     private $sqlEncoding;
 
     /**
+     * The property's identifier formatted for field names.
+     *
+     * @var string
+     */
+    private $fieldIdent;
+
+    /**
      * Store of the property's storage fields.
      *
      * @var PropertyField[]
      */
-    private $fields;
+    protected $fields;
+
+    /**
+     * Store of the property's storage field identifiers.
+     *
+     * @var string[]
+     */
+    protected $fieldNames;
+
+    /**
+     * Holds a list of all snake_case strings.
+     *
+     * @var string[]
+     */
+    protected static $snakeCache = [];
 
     /**
      * Retrieve the property's storage fields.
@@ -35,47 +56,79 @@ trait StorablePropertyTrait
      * @param  mixed $val The value to set as field value.
      * @return PropertyField[]
      */
-    public function fields($val)
+    public function fields($val = null)
     {
         if (empty($this->fields)) {
-            $this->generateFields($val);
+            $this->fields = $this->generateFields($val);
         } else {
-            $this->updatedFields($val);
+            $this->fields = $this->updatedFields($this->fields, $val);
         }
 
         return $this->fields;
     }
 
     /**
-     * Retrieve the property's storage field names.
+     * Retrieve the property's identifier formatted for field names.
+     *
+     * @param  string|null $key The field key to suffix to the property identifier.
+     * @return string|null Returns the property's field name.
+     *     If $key is provided, returns the namespaced field name otherwise NULL.
+     */
+    public function fieldIdent($key = null)
+    {
+        if ($this->fieldIdent === null) {
+            $this->fieldIdent = $this->snakeize($this['ident']);
+        }
+
+        if ($key === null || $key === '') {
+            return $this->fieldIdent;
+        }
+
+        if ($this->isValidFieldKey($key)) {
+            return $this->fieldIdent.'_'.$this->snakeize($key);
+        }
+
+        return null;
+    }
+
+    /**
+     * Retrieve the property's namespaced storage field names.
+     *
+     * Examples:
+     * 1. `name`: `name_en`, `name_fr`, `name_de`
+     * 2. `obj`: `obj_id`, `obj_type`
+     * 3. `file`: `file`, `file_type`
+     * 4. `opt`: `opt_0`, `opt_1`, `opt_2`
      *
      * @return string[]
      */
     public function fieldNames()
     {
-        $ident  = $this['ident'];
-        $fields = [];
-        if ($this['l10n']) {
-            foreach ($this->translator()->availableLocales() as $langCode) {
-                // Ensure snake_case
-                $fields[$langCode] = strtolower(preg_replace('/(?<!^)[A-Z]/', '_$0', $ident)).'_'.$langCode;
+        if ($this->fieldNames === null) {
+            $names = [];
+            if ($this['l10n']) {
+                $keys = $this->translator()->availableLocales();
+                foreach ($keys as $key) {
+                    $names[$key] = $this->fieldIdent($key);
+                }
+            } else {
+                $names[''] = $this->fieldIdent();
             }
-        } else {
-            // Ensure snake_case
-            $fields[] = strtolower(preg_replace('/(?<!^)[A-Z]/', '_$0', $ident));
+
+            $this->fieldNames = $names;
         }
 
-        return $fields;
+        return $this->fieldNames;
     }
 
     /**
-     * Retrieve the value of the property's given storage field.
+     * Retrieve the property's value in a format suitable for the given field key.
      *
-     * @param  string $fieldIdent The property field identifier.
-     * @param  mixed  $val        The value to set as field value.
+     * @param  string $key The property field key.
+     * @param  mixed  $val The value to set as field value.
      * @return mixed
      */
-    private function fieldVal($fieldIdent, $val)
+    protected function fieldValue($key, $val)
     {
         if ($val === null) {
             return null;
@@ -85,11 +138,15 @@ trait StorablePropertyTrait
             return $this->storageVal($val);
         }
 
-        if (isset($val[$fieldIdent])) {
-            return $this->storageVal($val[$fieldIdent]);
-        } else {
-            return null;
+        if (!$this->isValidFieldKey($key)) {
+            return $this->storageVal($val);
         }
+
+        if (isset($val[$key])) {
+            return $this->storageVal($val[$key]);
+        }
+
+        return null;
     }
 
     /**
@@ -127,26 +184,52 @@ trait StorablePropertyTrait
     }
 
     /**
+     * Parse the property's value (from a flattened structure)
+     * in a format suitable for models.
+     *
+     * This method takes a one-dimensional array and, depending on
+     * the property's {@see self::fieldNames() field structure},
+     * returns a complex array.
+     *
+     * @param  array $flatData The model data subset.
+     * @return mixed
+     */
+    public function parseFromFlatData(array $flatData)
+    {
+        $value = null;
+
+        $fieldNames = $this->fieldNames();
+        foreach ($fieldNames as $fieldKey => $fieldName) {
+            if ($this->isValidFieldKey($fieldKey)) {
+                if (isset($flatData[$fieldName])) {
+                    $value[$fieldKey] = $flatData[$fieldName];
+                }
+            } elseif (isset($flatData[$fieldName])) {
+                $value = $flatData[$fieldName];
+            }
+        }
+
+        return $value;
+    }
+
+    /**
      * Update the property's storage fields.
      *
-     * @param  mixed $val The value to set as field value.
+     * @param  PropertyField[] $fields The storage fields to update.
+     * @param  mixed           $val    The value to set as field value.
      * @return PropertyField[]
      */
-    private function updatedFields($val)
+    protected function updatedFields(array $fields, $val)
     {
-        if (empty($this->fields)) {
-            return $this->generateFields($val);
+        if (empty($fields)) {
+            $fields = $this->generateFields($val);
         }
 
-        if ($this['l10n']) {
-            foreach ($this->translator()->availableLocales() as $langCode) {
-                $this->fields[$langCode]->setVal($this->fieldVal($langCode, $val));
-            }
-        } else {
-            $this->fields[0]->setVal($this->storageVal($val));
+        foreach ($fields as $fieldKey => $field) {
+            $fields[$fieldKey]->setVal($this->fieldValue($fieldKey, $val));
         }
 
-        return $this->fields;
+        return $fields;
     }
 
     /**
@@ -155,39 +238,27 @@ trait StorablePropertyTrait
      * @param  mixed $val The value to set as field value.
      * @return PropertyField[]
      */
-    private function generateFields($val)
+    protected function generateFields($val = null)
     {
-        $this->fields = [];
-        if ($this['l10n']) {
-            foreach ($this->translator()->availableLocales() as $langCode) {
-                $ident = $this->l10nIdent($langCode);
-                $field = $this->createPropertyField([
-                    'ident'       => $ident,
-                    'sqlType'     => $this->sqlType(),
-                    'sqlPdoType'  => $this->sqlPdoType(),
-                    'sqlEncoding' => $this->sqlEncoding(),
-                    'extra'       => $this->sqlExtra(),
-                    'val'         => $this->fieldVal($langCode, $val),
-                    'defaultVal'  => null,
-                    'allowNull'   => $this['allowNull'],
-                ]);
-                $this->fields[$langCode] = $field;
-            }
-        } else {
+        $fields = [];
+
+        $fieldNames = $this->fieldNames();
+        foreach ($fieldNames as $fieldKey => $fieldName) {
             $field = $this->createPropertyField([
-                'ident'       => $this['ident'],
+                'ident'       => $fieldName,
                 'sqlType'     => $this->sqlType(),
                 'sqlPdoType'  => $this->sqlPdoType(),
                 'sqlEncoding' => $this->sqlEncoding(),
                 'extra'       => $this->sqlExtra(),
-                'val'         => $this->storageVal($val),
-                'defaultVal'  => null,
+                'val'         => $this->fieldValue($fieldKey, $val),
+                'defaultVal'  => $this->sqlDefaultVal(),
                 'allowNull'   => $this['allowNull'],
             ]);
-            $this->fields[] = $field;
+
+            $fields[$fieldKey] = $field;
         }
 
-        return $this->fields;
+        return $fields;
     }
 
     /**
@@ -196,15 +267,45 @@ trait StorablePropertyTrait
      */
     protected function createPropertyField(array $data = null)
     {
-        $field = new PropertyField([
-            'translator' => $this->translator(),
-        ]);
+        $field = new PropertyField();
 
         if ($data !== null) {
             $field->setData($data);
         }
 
         return $field;
+    }
+
+    /**
+     * Determine if the given value is a valid field key suffix.
+     *
+     * @param  mixed $key The key to test.
+     * @return boolean
+     */
+    protected function isValidFieldKey($key)
+    {
+        return (!empty($key) || is_numeric($key));
+    }
+
+    /**
+     * Transform a string from "camelCase" to "snake_case".
+     *
+     * @param  string $value The string to snakeize.
+     * @return string The snake_case string.
+     */
+    protected function snakeize($value)
+    {
+        $key = $value;
+
+        if (isset(static::$snakeCache[$key])) {
+            return static::$snakeCache[$key];
+        }
+
+        $value = strtolower(preg_replace('/(?<!^)[A-Z]/', '_$0', $value));
+
+        static::$snakeCache[$key] = $value;
+
+        return static::$snakeCache[$key];
     }
 
     /**
@@ -270,12 +371,6 @@ trait StorablePropertyTrait
      * @return string
      */
     abstract public function getIdent();
-
-    /**
-     * @param  string|null $lang The language code to return the identifier with.
-     * @return string
-     */
-    abstract public function l10nIdent($lang = null);
 
     /**
      * @return boolean

--- a/src/Charcoal/Property/StorablePropertyTrait.php
+++ b/src/Charcoal/Property/StorablePropertyTrait.php
@@ -16,17 +16,192 @@ use Charcoal\Property\PropertyField;
 trait StorablePropertyTrait
 {
     /**
+     * An empty value implies that the property will inherit the table's encoding.
+     *
+     * @var string
+     */
+    private $sqlEncoding = '';
+
+    /**
      * Store of the property's storage fields.
      *
-     * @var PropertyField[]|null
+     * @var PropertyField[]
      */
     private $fields;
 
     /**
-     * An empty value implies that the property will inherit the table's encoding
-     * @var string
+     * Retrieve the property's storage fields.
+     *
+     * @param  mixed $val The value to set as field value.
+     * @return PropertyField[]
      */
-    private $sqlEncoding = '';
+    public function fields($val)
+    {
+        if (empty($this->fields)) {
+            $this->generateFields($val);
+        } else {
+            $this->updatedFields($val);
+        }
+
+        return $this->fields;
+    }
+
+    /**
+     * Retrieve the property's storage field names.
+     *
+     * @return string[]
+     */
+    public function fieldNames()
+    {
+        $ident  = $this['ident'];
+        $fields = [];
+        if ($this['l10n']) {
+            foreach ($this->translator()->availableLocales() as $langCode) {
+                // Ensure snake_case
+                $fields[$langCode] = strtolower(preg_replace('/(?<!^)[A-Z]/', '_$0', $ident)).'_'.$langCode;
+            }
+        } else {
+            // Ensure snake_case
+            $fields[] = strtolower(preg_replace('/(?<!^)[A-Z]/', '_$0', $ident));
+        }
+
+        return $fields;
+    }
+
+    /**
+     * Retrieve the value of the property's given storage field.
+     *
+     * @param  string $fieldIdent The property field identifier.
+     * @param  mixed  $val        The value to set as field value.
+     * @return mixed
+     */
+    private function fieldVal($fieldIdent, $val)
+    {
+        if ($val === null) {
+            return null;
+        }
+
+        if (is_scalar($val)) {
+            return $this->storageVal($val);
+        }
+
+        if (isset($val[$fieldIdent])) {
+            return $this->storageVal($val[$fieldIdent]);
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Retrieve the property's value in a format suitable for storage.
+     *
+     * @param  mixed $val The value to convert for storage.
+     * @return mixed
+     */
+    public function storageVal($val)
+    {
+        if ($val === null) {
+            // Do not json_encode NULL values
+            return null;
+        }
+
+        if (!$this['l10n'] && $val instanceof Translation) {
+            $val = (string)$val;
+        }
+
+        if ($this['multiple']) {
+            if (is_array($val)) {
+                $val = implode($this->multipleSeparator(), $val);
+            }
+        }
+
+        if (!is_scalar($val)) {
+            return json_encode($val, JSON_UNESCAPED_UNICODE);
+        }
+
+        return $val;
+    }
+
+    /**
+     * Update the property's storage fields.
+     *
+     * @param  mixed $val The value to set as field value.
+     * @return PropertyField[]
+     */
+    private function updatedFields($val)
+    {
+        if (empty($this->fields)) {
+            return $this->generateFields($val);
+        }
+
+        if ($this['l10n']) {
+            foreach ($this->translator()->availableLocales() as $langCode) {
+                $this->fields[$langCode]->setVal($this->fieldVal($langCode, $val));
+            }
+        } else {
+            $this->fields[0]->setVal($this->storageVal($val));
+        }
+
+        return $this->fields;
+    }
+
+    /**
+     * Reset the property's storage fields.
+     *
+     * @param  mixed $val The value to set as field value.
+     * @return PropertyField[]
+     */
+    private function generateFields($val)
+    {
+        $this->fields = [];
+        if ($this['l10n']) {
+            foreach ($this->translator()->availableLocales() as $langCode) {
+                $ident = $this->l10nIdent($langCode);
+                $field = $this->createPropertyField([
+                    'ident'       => $ident,
+                    'sqlType'     => $this->sqlType(),
+                    'sqlPdoType'  => $this->sqlPdoType(),
+                    'sqlEncoding' => $this->sqlEncoding(),
+                    'extra'       => $this->sqlExtra(),
+                    'val'         => $this->fieldVal($langCode, $val),
+                    'defaultVal'  => null,
+                    'allowNull'   => $this['allowNull'],
+                ]);
+                $this->fields[$langCode] = $field;
+            }
+        } else {
+            $field = $this->createPropertyField([
+                'ident'       => $this['ident'],
+                'sqlType'     => $this->sqlType(),
+                'sqlPdoType'  => $this->sqlPdoType(),
+                'sqlEncoding' => $this->sqlEncoding(),
+                'extra'       => $this->sqlExtra(),
+                'val'         => $this->storageVal($val),
+                'defaultVal'  => null,
+                'allowNull'   => $this['allowNull'],
+            ]);
+            $this->fields[] = $field;
+        }
+
+        return $this->fields;
+    }
+
+    /**
+     * @param  array $data Optional. Field data.
+     * @return PropertyField
+     */
+    protected function createPropertyField(array $data = null)
+    {
+        $field = new PropertyField([
+            'translator' => $this->translator(),
+        ]);
+
+        if ($data !== null) {
+            $field->setData($data);
+        }
+
+        return $field;
+    }
 
     /**
      * Set the property's SQL encoding & collation.
@@ -58,74 +233,6 @@ trait StorablePropertyTrait
     public function sqlEncoding()
     {
         return $this->sqlEncoding;
-    }
-
-    /**
-     * Retrieve the property's storage fields.
-     *
-     * @param  mixed $val The value to set as field value.
-     * @return PropertyField[]
-     */
-    public function fields($val)
-    {
-        if (empty($this->fields)) {
-            $this->generateFields($val);
-        } else {
-            $this->updatedFields($val);
-        }
-
-        return $this->fields;
-    }
-
-    /**
-     * Retrieve the property's storage field names.
-     *
-     * @return string[]
-     */
-    public function fieldNames()
-    {
-        $fields = [];
-        if ($this['l10n']) {
-            foreach ($this->translator()->availableLocales() as $langCode) {
-                // Ensure snake_case
-                $fields[$langCode] = strtolower(preg_replace('/(?<!^)[A-Z]/', '_$0', $this->ident())).'_'.$langCode;
-            }
-        } else {
-            // Ensure snake_case
-            $fields[] = strtolower(preg_replace('/(?<!^)[A-Z]/', '_$0', $this->ident()));
-        }
-
-        return $fields;
-    }
-
-    /**
-     * Retrieve the property's value in a format suitable for storage.
-     *
-     * @param  mixed $val The value to convert for storage.
-     * @return mixed
-     */
-    public function storageVal($val)
-    {
-        if ($val === null) {
-            // Do not json_encode NULL values
-            return null;
-        }
-
-        if (!$this['l10n'] && $val instanceof Translation) {
-            $val = (string)$val;
-        }
-
-        if ($this['multiple']) {
-            if (is_array($val)) {
-                $val = implode($this->multipleSeparator(), $val);
-            }
-        }
-
-        if (!is_scalar($val)) {
-            return json_encode($val, JSON_UNESCAPED_UNICODE);
-        }
-
-        return $val;
     }
 
     /**
@@ -178,112 +285,7 @@ trait StorablePropertyTrait
     abstract public function getAllowNull();
 
     /**
-     * @param  array $data Optional. Field data.
-     * @return PropertyField
-     */
-    protected function createPropertyField(array $data = null)
-    {
-        $field = new PropertyField([
-            'translator' => $this->translator()
-        ]);
-
-        if ($data !== null) {
-            $field->setData($data);
-        }
-
-        return $field;
-    }
-
-    /**
      * @return \Charcoal\Translator\Translator
      */
     abstract protected function translator();
-
-    /**
-     * Update the property's storage fields.
-     *
-     * @param  mixed $val The value to set as field value.
-     * @return PropertyField[]
-     */
-    private function updatedFields($val)
-    {
-        if (empty($this->fields)) {
-            return $this->generateFields($val);
-        }
-
-        if ($this['l10n']) {
-            foreach ($this->translator()->availableLocales() as $langCode) {
-                $this->fields[$langCode]->setVal($this->fieldVal($langCode, $val));
-            }
-        } else {
-            $this->fields[0]->setVal($this->storageVal($val));
-        }
-
-        return $this->fields;
-    }
-
-    /**
-     * Reset the property's storage fields.
-     *
-     * @param  mixed $val The value to set as field value.
-     * @return PropertyField[]
-     */
-    private function generateFields($val)
-    {
-        $this->fields = [];
-        if ($this['l10n']) {
-            foreach ($this->translator()->availableLocales() as $langCode) {
-                $ident = $this->l10nIdent($langCode);
-                $field = $this->createPropertyField([
-                    'ident'       => $ident,
-                    'sqlType'     => $this->sqlType(),
-                    'sqlPdoType'  => $this->sqlPdoType(),
-                    'sqlEncoding' => $this->sqlEncoding(),
-                    'extra'       => $this->sqlExtra(),
-                    'val'         => $this->fieldVal($langCode, $val),
-                    'defaultVal'  => null,
-                    'allowNull'   => $this['allowNull']
-                ]);
-                $this->fields[$langCode] = $field;
-            }
-        } else {
-            $field = $this->createPropertyField([
-                'ident'       => $this->ident(),
-                'sqlType'     => $this->sqlType(),
-                'sqlPdoType'  => $this->sqlPdoType(),
-                'sqlEncoding' => $this->sqlEncoding(),
-                'extra'       => $this->sqlExtra(),
-                'val'         => $this->storageVal($val),
-                'defaultVal'  => null,
-                'allowNull'   => $this['allowNull']
-            ]);
-            $this->fields[] = $field;
-        }
-
-        return $this->fields;
-    }
-
-    /**
-     * Retrieve the value of the property's given storage field.
-     *
-     * @param  string $fieldIdent The property field identifier.
-     * @param  mixed  $val        The value to set as field value.
-     * @return mixed
-     */
-    private function fieldVal($fieldIdent, $val)
-    {
-        if ($val === null) {
-            return null;
-        }
-
-        if (is_scalar($val)) {
-            return $this->storageVal($val);
-        }
-
-        if (isset($val[$fieldIdent])) {
-            return $this->storageVal($val[$fieldIdent]);
-        } else {
-            return null;
-        }
-    }
 }

--- a/tests/Charcoal/Property/BooleanPropertyTest.php
+++ b/tests/Charcoal/Property/BooleanPropertyTest.php
@@ -145,7 +145,7 @@ class BooleanPropertyTest extends AbstractTestCase
     public function testSqlExtra()
     {
         $obj = $this->obj;
-        $this->assertSame('', $obj->sqlExtra());
+        $this->assertSame(null, $obj->sqlExtra());
     }
 
     /**

--- a/tests/Charcoal/Property/DateTimePropertyTest.php
+++ b/tests/Charcoal/Property/DateTimePropertyTest.php
@@ -385,7 +385,7 @@ class DateTimePropertyTest extends AbstractTestCase
      */
     public function testSqlExtra()
     {
-        $this->assertSame('', $this->obj->sqlExtra());
+        $this->assertSame(null, $this->obj->sqlExtra());
     }
 
     /**

--- a/tests/Charcoal/Property/PropertyFieldTest.php
+++ b/tests/Charcoal/Property/PropertyFieldTest.php
@@ -5,9 +5,6 @@ namespace Charcoal\Tests\Property;
 use PDO;
 use InvalidArgumentException;
 
-// From 'charcoal-translator'
-use Charcoal\Translator\Translation;
-
 // From 'charcoal-property'
 use Charcoal\Property\PropertyField;
 use Charcoal\Tests\AbstractTestCase;
@@ -102,7 +99,7 @@ class PropertyFieldTest extends AbstractTestCase
         $this->assertSame($this->obj, $ret);
 
         $label = $this->obj->label();
-        $this->assertInstanceOf(Translation::class, $label);
+        $this->assertInternalType('string', $label);
         $this->assertEquals('Cooking', (string)$label);
     }
 
@@ -136,7 +133,7 @@ class PropertyFieldTest extends AbstractTestCase
         $this->assertEquals('INT(10)', $this->obj->sqlType());
 
         $this->expectException(InvalidArgumentException::class);
-        $this->obj->setSqlType(null);
+        $this->obj->setSqlType(0);
     }
 
     /**
@@ -152,7 +149,7 @@ class PropertyFieldTest extends AbstractTestCase
         $this->assertEquals('UNSIGNED', $this->obj->extra());
 
         $this->expectException(InvalidArgumentException::class);
-        $this->obj->setExtra(null);
+        $this->obj->setExtra(0);
     }
 
     /**
@@ -168,6 +165,6 @@ class PropertyFieldTest extends AbstractTestCase
         $this->assertEquals('UNSIGNED', $this->obj->sqlEncoding());
 
         $this->expectException(InvalidArgumentException::class);
-        $this->obj->setSqlEncoding(null);
+        $this->obj->setSqlEncoding(0);
     }
 }


### PR DESCRIPTION
Related:
- locomotivemtl/charcoal-core#8
- locomotivemtl/charcoal-admin#32

---

Decouple L10N field generation to allow for custom or existing properties to support custom property fields.