### PR TITLE
Add "validatable" flag to Properties

### DIFF
--- a/src/Charcoal/Property/AbstractProperty.php
+++ b/src/Charcoal/Property/AbstractProperty.php
@@ -63,6 +63,7 @@ abstract class AbstractProperty extends AbstractEntity implements
     const DEFAULT_REQUIRED = false;
     const DEFAULT_ALLOW_NULL = true;
     const DEFAULT_STORABLE = true;
+    const DEFAULT_VALIDATABLE = true;
     const DEFAULT_ACTIVE = true;
 
     /**
@@ -126,6 +127,12 @@ abstract class AbstractProperty extends AbstractEntity implements
      * @var boolean
      */
     private $storable = self::DEFAULT_STORABLE;
+
+    /**
+     * Whether to validate the property.
+     * @var boolean
+     */
+    private $validatable = self::DEFAULT_VALIDATABLE;
 
     /**
      * Inactive properties should be hidden everywhere / unused
@@ -780,6 +787,25 @@ abstract class AbstractProperty extends AbstractEntity implements
     public function active()
     {
         return $this->getActive();
+    }
+
+    /**
+     * @param  boolean $validatable The validatable flag.
+     * @return self
+     */
+    public function setValidatable($validatable)
+    {
+        $this->validatable = !!$validatable;
+
+        return $this;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function getValidatable()
+    {
+        return $this->validatable;
     }
 
     /**

--- a/src/Charcoal/Property/AbstractProperty.php
+++ b/src/Charcoal/Property/AbstractProperty.php
@@ -863,7 +863,8 @@ abstract class AbstractProperty extends AbstractEntity implements
      */
     public function validateRequired()
     {
-        if ($this['required'] && !$this->val()) {
+        $val = $this->val();
+        if ($this['required'] && empty($val) && !is_numeric($val)) {
             $this->validator()->error('Value is required.', 'required');
 
             return false;
@@ -890,7 +891,8 @@ abstract class AbstractProperty extends AbstractEntity implements
      */
     public function validateAllowNull()
     {
-        if (!$this['allowNull'] && $this->val() === null) {
+        $val = $this->val();
+        if (!$this['allowNull'] && $val === null) {
             $this->validator()->error('Value can not be null.', 'allowNull');
 
             return false;

--- a/src/Charcoal/Property/PropertyValidator.php
+++ b/src/Charcoal/Property/PropertyValidator.php
@@ -21,6 +21,10 @@ class PropertyValidator extends AbstractValidator
         // The model, in this case, should be a PropertyInterface
         $property = $this->model;
 
+        if (!$property['validatable']) {
+            return true;
+        }
+
         $methods = $property->validationMethods();
         foreach ($methods as $method) {
             $method = $this->camelize($method);

--- a/src/Charcoal/Property/StringProperty.php
+++ b/src/Charcoal/Property/StringProperty.php
@@ -440,12 +440,13 @@ class StringProperty extends AbstractProperty implements SelectablePropertyInter
     public function validateAllowEmpty()
     {
         $val = $this->val();
+        if (!$this['allowEmpty'] && empty($val) && !is_numeric($val)) {
+            $this->validator()->error('Value can not be empty.', 'allowEmpty');
 
-        if (($val === null || $val === '') && !$this['allowEmpty']) {
             return false;
-        } else {
-            return true;
         }
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
Added support for ignoring validation of any Property.

For example, disabling validation is useful for Properties that do not support validation of multi-values.

```
"documents": {
    "type": "file",
    "multiple": true,
    "validatable": false,
    "upload_path": "uploads/documents/"
}
```